### PR TITLE
Fix .travis.yaml allow_failures syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ stages:
 - snapshot-2
 - extra-dependencies
 - tests
+- documentation
 
 # Install foreign dependencies required by some modules below
 before_install:
@@ -67,7 +68,7 @@ before_install:
 # everything in one go.
 # Before kicking this action, it would also be advised to cleanup the entire cache.
 snapshot-1: &snapshot-1
-  if: type != cron AND commit_message =~ /ci@update lts/
+  if: commit_message =~ /ci@update lts/
   script:
   # Prepare directories
   - mkdir -p $HOME/.local/bin $HOME/.local/lib $HOME/.local/include
@@ -91,7 +92,7 @@ snapshot-1: &snapshot-1
 # Build out custom snapshot on top of the LTS. We separate this from the lts job to split
 # the workload and have two jobs running < 50 mins.
 snapshot-2: &snapshot-2
-  if: type != cron AND commit_message =~ /ci@update lts/
+  if: commit_message =~ /ci@update lts/
   script:
   # Install rest of the the snapshot, mostly servant and cardano-sl
   - travis_wait 42 stack --no-terminal build --only-snapshot --ghc-options "+RTS -A256m -n2m -M3G -RTS"
@@ -106,7 +107,7 @@ snapshot-2: &snapshot-2
 # Still, we build that as a separate job and only triggers it when appropriated. It's cached
 # otherwise.
 extra-dependencies: &extra-dependencies
-  if: type != cron AND commit_message =~ /ci@update stack.yaml/
+  if: commit_message =~ /ci@update stack.yaml/
   env:
     - ACTION=coverage
     - ACTION=documentation
@@ -153,32 +154,28 @@ jobs:
   # HLINT
   - stage: tests
     env: ACTION=hlint
-    if: type != cron
     script:
       - curl -sL https://raw.github.com/ndmitchell/hlint/bea72e4e61da54ecd451590734d6e10423ead100/misc/travis.sh | sh -s . --cpp-define=__GLASGOW_HASKELL__=800 --cpp-define=x86_64_HOST_ARCH=1 --cpp-define=mingw32_HOST_OS=1
 
   # COVERAGE
   - stage: tests
     env: ACTION=coverage
-    if: type != cron
     # Run all tests with code coverage
     script:
     - tar xzf $HOME/.local/stack-work.tar.gz # Cached extra-dependencies
     - travis_wait 42 stack --no-terminal test cardano-wallet:test:unit --fast --coverage --ghc-options "+RTS -A256m -n2m -M3G -RTS"
     - shc cardano-wallet unit
 
-  allow_failures:
   # WEEDER
-  - stage: weeder
+  - stage: tests
     env: ACTION=weeder
-    if: type = cron
     script:
     - tar xzf $HOME/.local/stack-work.tar.gz # Cached extra-dependencies
-    - travis_wait 42 stack --no-terminal build --fast --ghc-options "+RTS -A256m -n2m -M3G -RTS"
+    - travis_wait 42 stack --no-terminal test --no-run-tests --fast --ghc-options "+RTS -A256m -n2m -M3G -RTS"
     - curl -sSL https://raw.github.com/ndmitchell/weeder/master/misc/travis.sh | sh -s .
 
   # DOCUMENTATION
-  - stage: tests
+  - stage: documentation
     env: ACTION=documentation
     if: type = push AND branch = develop
     # Upload API doc automatically on each build against `develop` to `gh-pages`
@@ -189,3 +186,7 @@ jobs:
     - git add swagger.json && git commit -m $TRAVIS_COMMIT
     - git checkout gh-pages && git cherry-pick -X theirs -
     - git push -f -q https://KtorZ:$GITHUB_API_KEY@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null # TODO: Create a specific CI user with its own key
+
+  allow_failures:
+    - env: ACTION=documentation
+    - env: ACTION=weeder


### PR DESCRIPTION
# Linked Issue

<Put here a reference to the issue this PR relates to and which requirements it tackles>

<p align="right">#81</p>

### Acceptance criteria:

1. - [x] The "documentation" job _must_ be ran as part of the CI after each merge on `develop`
2. - [x] The "weeder" job _should_ be ran on each PR, in parallel 
3. - [x] The "weeder" job _may_ allows failure for now

# Comments

<Additional comments or screenshots to attach>

Note, I've also moved `weeder` to be done on each PR with allowed failures (for now). I'll remove the corresponding cron job. The rational is that, for now, it's not possible (or I didn't find how) to see build status of cron jobs on travis :thinking: ... So this is basically useless since weeder just outputs stuff in the logs; if we ain't read it, it's pointless.

# Checklist

- [x] I've kept this PR simple, on-the-spot, free of cosmetic changes.
- [x] I have reviewed my commit messages and history.
- [x] I've assigned a reviewer.
- [x] I acknowledge my changes may require an update in the wiki.
- [ ] I have added a reference to this PR to the corresponding issue.

---

- [x] I've checked the checklist
