### PR TITLE
Remove use of V1 wrapper: PassPhrase

### DIFF
--- a/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
@@ -187,7 +187,7 @@ redeemAda aw
           V1.Redemption{
               redemptionRedemptionCode   = code
             , redemptionMnemonic         = mMnemonic
-            , redemptionSpendingPassword = V1.V1 spendingPassword
+            , redemptionSpendingPassword = V1.WalletPassPhrase spendingPassword
             , redemptionWalletId         = wId
             , redemptionAccountIndex     = accIx
             } = runExceptT $ do

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -210,8 +210,8 @@ updateWalletPassword :: MonadIO m
 updateWalletPassword wallet
                      wId
                      (V1.PasswordUpdate
-                       (V1 oldPwd)
-                       (V1 newPwd)) = runExceptT $ do
+                       (V1.WalletPassPhrase oldPwd)
+                       (V1.WalletPassPhrase newPwd)) = runExceptT $ do
     rootId <- withExceptT UpdateWalletPasswordWalletIdDecodingFailed $
                 fromRootId wId
     v1wal <- fmap (uncurry toWallet) $

--- a/test/unit/API/MarshallingSpec.hs
+++ b/test/unit/API/MarshallingSpec.hs
@@ -62,7 +62,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @NewWallet Proxy
         aesonRoundtripProp @NewAddress Proxy
         aesonRoundtripProp @(V1 Core.Coin) Proxy
-        aesonRoundtripProp @(V1 Crypto.PassPhrase) Proxy
+        aesonRoundtripProp @WalletPassPhrase Proxy
         aesonRoundtripProp @(V1 InputSelectionPolicy) Proxy
         aesonRoundtripProp @TimeInfo Proxy
         aesonRoundtripProp @Transaction Proxy
@@ -162,13 +162,13 @@ spec = describe "Marshalling & Unmarshalling" $ do
     describe "Invariants" $ do
         describe "password" $ do
             it "empty string decodes to empty password" $
-                jsonString "" `decodesTo` (== V1 (Crypto.emptyPassphrase))
+                jsonString "" `decodesTo` (== WalletPassPhrase (Crypto.emptyPassphrase))
             it "base-16 string of length 32 decodes to nonempty password" $
                 jsonString (fromString $ replicate 64 'a')
-                    `decodesTo` (/= V1 (Crypto.emptyPassphrase))
+                    `decodesTo` (/= WalletPassPhrase (Crypto.emptyPassphrase))
             it "invalid length password decoding fails" $
                 -- currently passphrase should be either empty or of length 32
-                decodingFails @(V1 Crypto.PassPhrase) "aabbcc" Proxy
+                decodingFails @WalletPassPhrase "aabbcc" Proxy
 
     describe "Timestamp Parsing" $ do
         describe "ToIndex" $ do

--- a/test/unit/Golden/APIV1Types.hs
+++ b/test/unit/Golden/APIV1Types.hs
@@ -7,7 +7,7 @@ import           Universum
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Cardano.Wallet.API.V1.Types (WalletPassPhrase (..))
 import           Pos.Crypto (PassPhrase (..))
 
 import           Test.Pos.Util.Golden (discoverGolden, goldenTestJSON)
@@ -27,7 +27,7 @@ tests =
 golden_WalletPassPhrase :: Property
 golden_WalletPassPhrase =
     goldenTestJSON
-        (V1 examplePassPhrase)
+        (WalletPassPhrase examplePassPhrase)
         "test/unit/Golden/golden/apiV1Types/json/PassPhrase"
 
 -------------------------------------------------------------------------------

--- a/test/unit/Test/Spec/Wallets.hs
+++ b/test/unit/Test/Spec/Wallets.hs
@@ -43,7 +43,6 @@ import qualified Cardano.Wallet.API.Request.Pagination as API
 import qualified Cardano.Wallet.API.Response as V1
 import           Cardano.Wallet.API.V1.Handlers.Accounts as Handlers
 import           Cardano.Wallet.API.V1.Handlers.Wallets as Handlers
-import           Cardano.Wallet.API.V1.Types (V1 (..), unV1)
 import qualified Cardano.Wallet.API.V1.Types as V1
 import           Control.Monad.Except (runExceptT)
 import           Servant.Server
@@ -336,9 +335,10 @@ spec = describe "Wallets" $ do
                         let nm  = makeNetworkMagic pm
                             wid = WalletIdHdRnd fixtureHdRootId
                         oldKey <- Keystore.lookup nm wid keystore
+                        let V1.WalletPassPhrase corePassword = fixtureSpendingPassword
                         res <- Kernel.updatePassword wallet
                                                      fixtureHdRootId
-                                                     (unV1 fixtureSpendingPassword)
+                                                     corePassword
                                                      newPwd
                         case res of
                              Left e -> fail (show e)
@@ -353,9 +353,10 @@ spec = describe "Wallets" $ do
                     newPwd <- pick arbitrary
                     pm     <- pick arbitrary
                     withNewWalletFixture pm $ \ _ _ wallet Fixture{..} -> do
+                        let V1.WalletPassPhrase corePassword = fixtureSpendingPassword
                         res <- Kernel.updatePassword wallet
                                                      fixtureHdRootId
-                                                     (unV1 fixtureSpendingPassword)
+                                                     corePassword
                                                      newPwd
                         let passphraseIsEmpty = newPwd == emptyPassphrase
                         let satisfied = \case


### PR DESCRIPTION
# Linked Issue

<Put here a reference to the issue this PR relates to and which requirements it tackles>

<p align="right">#119</p>


# Overview

<Detail in a few bullet points the work accomplished in this PR>

1. - [x] Type `Core.PassPhrase` doesn't use `V1` wrapper.
2. - [x] newtype `WalletPassPhrase` is introduced instead.

# Comments

<Additional comments or screenshots to attach if any>

¯\\\_(ツ)\_/¯


# Checklist

- [x] I've kept this PR simple, on-the-spot, free of cosmetic changes.
- [x] I have reviewed my commit messages and history.
- [x] I've assigned a reviewer.
- [x] I acknowledge my changes may require an update in the wiki.
- [x] I have added a reference to this PR to the corresponding issue.

---

- [x] I've checked the checklist
