### PR TITLE
[BIP44-D-#34] Part 1 - Abstract ids for Wallet/Account/Address in pre…

### DIFF
--- a/src/Cardano/Wallet/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/Kernel/Accounts.hs
@@ -93,6 +93,8 @@ createAccount spendingPassword accountName walletId pw = do
                                          esk
                                          hdRootId
                                          pw
+         WalletIdEOS _eosWalletId ->
+              error "TO BE IMPLEMENTED @uroboros #34"
 
 -- | Creates a new 'Account' using the random HD derivation under the hood.
 -- This code follows the same pattern of 'createHdRndAddress', but the two

--- a/src/Cardano/Wallet/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/Kernel/Addresses.hs
@@ -111,6 +111,8 @@ createAddress spendingPassword accId pw = do
                   Nothing  -> return (Left $ CreateAddressKeystoreNotFound accId)
                   Just esk -> createHdRndAddress spendingPassword esk hdAccId pw
 
+         (AccountIdEOS _accountPK) -> error "TO BE IMPLEMENTED @uroboros #34"
+
 -- | Creates a new 'Address' using the random HD derivation under the hood.
 -- Being this an operation bound not only by the number of available derivation
 -- indexes \"left\" in the account, some form of short-circuiting is necessary.

--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -333,6 +333,7 @@ switchToFork pw@PassiveWallet{..} oldest bs = do
             restoringWals = Set.fromList $
               Map.keys restorationInfo <&> \case
                 WalletIdHdRnd rootId -> rootId
+                WalletIdEOS _rootId -> error "TO BE IMPLEMENTED @uroboros #34"
         -- Stop the restorations.
         mapM_ cancelRestoration restorations
         -- Switch to the fork, retrying if another restoration begins in the meantime.

--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -44,7 +44,7 @@ import           Cardano.Wallet.Kernel.DB.TxMeta.Types
 import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock (..),
-                     prefilterBlock)
+                     prefilterBlockHdRnd, toHdRndPrefKeys)
 import           Cardano.Wallet.Kernel.Read (foreignPendingByAccount,
                      getWalletCredentials, getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Restore
@@ -75,8 +75,9 @@ prefilterBlocks pw bs = do
     res <- getWalletCredentials pw
     foreignPendings <- foreignPendingByAccount <$> getWalletSnapshot pw
     return $ case res of
-         [] -> Nothing
-         xs -> Just $ map (\b -> first (b ^. rbContext,) $ prefilterBlock nm foreignPendings b xs) bs
+         []   -> Nothing
+         wKeys -> Just $ map (\b -> first (b ^. rbContext,) $ prefilterBlockHdRnd (toHdRndPrefKeys nm wKeys) foreignPendings b)
+                             bs
 
 data BackfillFailed
     = SuccessorChanged BlockContext (Maybe BlockContext)

--- a/src/Cardano/Wallet/Kernel/EosWalletId.hs
+++ b/src/Cardano/Wallet/Kernel/EosWalletId.hs
@@ -61,6 +61,8 @@ instance Example EosWalletId where
     example = EosWalletId <$>
         pure (Prelude.read "c2cc10e1-57d6-4b6f-9899-38d972112d8c")
 
+instance NFData EosWalletId
+
 deriveJSON Aeson.defaultOptions ''EosWalletId
 
 -- | Generator for new 'EosWalletId'.

--- a/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -268,6 +268,7 @@ lookup nm wId (Keystore ks) =
 lookupKey :: NetworkMagic -> UserSecret -> WalletId -> Maybe EncryptedSecretKey
 lookupKey nm us (WalletIdHdRnd walletId) =
     Data.List.find (\k -> eskToHdRootId nm k == walletId) (us ^. usKeys)
+lookupKey _ _ (WalletIdEOS _walletId) = Nothing -- EOS wallets don't have any keys
 
 -- | Return all Keystore 'usKeys'
 getKeys :: Keystore -> IO [EncryptedSecretKey]

--- a/src/Cardano/Wallet/Kernel/Types.hs
+++ b/src/Cardano/Wallet/Kernel/Types.hs
@@ -14,10 +14,8 @@ module Cardano.Wallet.Kernel.Types (
   , WalletId (..)
   , AccountId (..)
   , AddressId (..)
-  , AddressIx (..)
   , accountToWalletId
   , addrIdToAccountId
-  , mkAddressId
     -- ** From raw to derived types
   , fromRawResolvedTx
   , fromRawResolvedBlock
@@ -100,29 +98,12 @@ data AddressId =
   | AddressIdEOS PublicKey Word --
     deriving (Eq, Ord)
 
--- | Address Ix
---
--- An AddressIx can take several forms
-data AddressIx =
-    -- | Randomly generated address index
-    AddressIxHdRnd HD.HdAddressIx
-    -- | Sequentially generated address index for EOS wallets
-  | AddressIxEOS Word
-    deriving (Eq, Ord)
-
 -- | Convert a generic AddressId to a generic AccountId
 addrIdToAccountId :: AddressId -> AccountId
 addrIdToAccountId (AddressIdHdRnd addrId)
     = AccountIdHdRnd (addrId ^. HD.hdAddressIdParent)
 addrIdToAccountId (AddressIdEOS parentAccountId _)
     = AccountIdEOS parentAccountId
-
-mkAddressId :: (AccountId, AddressIx) -> AddressId
-mkAddressId (AccountIdHdRnd accountId, AddressIxHdRnd addressIx)
-    = AddressIdHdRnd (HD.HdAddressId accountId addressIx)
-mkAddressId (AccountIdEOS accountPK, AddressIxEOS addressIx)
-    = AddressIdEOS accountPK addressIx
-mkAddressId _ = error "Cannot construct AddressId"
 
 {-------------------------------------------------------------------------------
   Input resolution: raw types

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -137,7 +137,9 @@ prepareFixtures nm initialBalance = do
         forM_ fixt $ \Fix{..} -> do
             liftIO $ Keystore.insert (WalletIdHdRnd fixtureHdRootId) fixtureESK keystore
 
-            let accounts    = Kernel.prefilterUtxo nm fixtureHdRootId fixtureESK fixtureUtxo
+            let prefKey     = Kernel.toHdRndPrefKey nm fixtureHdRootId fixtureESK
+                accounts    = Kernel.prefilterUtxoHdRnd prefKey fixtureUtxo
+
                 hdAccountId = Kernel.defaultHdAccountId fixtureHdRootId
                 hdAddress   = Kernel.defaultHdAddress nm fixtureESK emptyPassphrase fixtureHdRootId
 
@@ -175,7 +177,9 @@ prepareUTxoFixtures nm coins = do
     return $ \keystore aw -> do
         let pw = Kernel.walletPassive aw
         Keystore.insert (WalletIdHdRnd newRootId) esk keystore
-        let accounts    = Kernel.prefilterUtxo nm newRootId esk utxo
+        let prefKey     = Kernel.toHdRndPrefKey nm newRootId esk
+            accounts    = Kernel.prefilterUtxoHdRnd prefKey utxo
+
             hdAccountId = Kernel.defaultHdAccountId newRootId
             hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 

--- a/test/unit/Test/Spec/NewPayment.hs
+++ b/test/unit/Test/Spec/NewPayment.hs
@@ -116,7 +116,8 @@ prepareFixtures nm initialBalance toPay = do
         liftIO $ Keystore.insert (WalletIdHdRnd newRootId) esk keystore
         let pw = Kernel.walletPassive aw
 
-        let accounts    = Kernel.prefilterUtxo nm newRootId esk utxo'
+        let prefKey     = Kernel.toHdRndPrefKey nm newRootId esk
+            accounts    = Kernel.prefilterUtxoHdRnd prefKey utxo'
             hdAccountId = Kernel.defaultHdAccountId newRootId
             hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 

--- a/test/unit/Wallet/Inductive/Cardano.hs
+++ b/test/unit/Wallet/Inductive/Cardano.hs
@@ -42,7 +42,7 @@ import qualified Cardano.Wallet.Kernel.Internal as Internal
 import           Cardano.Wallet.Kernel.Invariants as Kernel
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import qualified Cardano.Wallet.Kernel.Pending as Kernel
-import           Cardano.Wallet.Kernel.PrefilterTx (prefilterUtxo)
+import           Cardano.Wallet.Kernel.PrefilterTx (prefilterUtxoHdRnd, toHdRndPrefKey)
 import qualified Cardano.Wallet.Kernel.Read as Kernel
 import           Cardano.Wallet.Kernel.Transactions (toMeta)
 
@@ -245,7 +245,8 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
                 Left $ DB.CreateHdWallet root
                                          defaultAccount
                                          defAddress
-                                         (prefilterUtxo nm (root ^. HD.hdRootId) esk utxo)
+                                         (prefilterUtxoHdRnd (toHdRndPrefKey nm (root ^. HD.hdRootId) esk)
+                                                              utxo)
             )
         case res of
              Left e -> createWalletErr (STB e)
@@ -258,7 +259,8 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
             walletName       = HD.WalletName "(test wallet)"
             assuranceLevel   = HD.AssuranceLevelNormal
 
-            utxoByAccount = prefilterUtxo nm rootId esk utxo
+            prefKey       = toHdRndPrefKey nm rootId esk
+            utxoByAccount = prefilterUtxoHdRnd prefKey utxo
             accountIds    = Map.keys utxoByAccount
             rootId        = HD.eskToHdRootId nm esk
 


### PR DESCRIPTION
…filtering module

# Linked Issue

https://github.com/input-output-hk/cardano-wallet/issues/34

<p align="right">#</p>


# Overview

## Commit 1 - Abstract Ids in Prefiltering module 

* to prepare for abstraction over different wallet types (HdRnd/EOS for now) in the prefiltering code, we need generic `WalletId/AccountId/AddressId` types instead of HdRnd specific ones
* the return types of the core prefiltering api have a non-trivial impact on the wallet Kernel, including the AcidState DB types. To limit the impact of this, I've added scaffolding to `PrefilterTx.hs` to keep the API types intact for now. This code will be removed as part of #34 

## Commit 2 - Polymorphic prefiltering with IsOurs + PrefilterKey

For the Prefiltering API - prefilterUtxo/prefilterBlock/filterOurs: 

* refactor to generic prefiltering (from HdRnd specific)
* define polymorhic API by dispatching isOurs on the new PrefilterKey sum type (defined for multiple wallets types)
* simplify API by refactoring some custom prefiltering happening in Restore.hs
* decouple HdRnd specific code from generic prefiltering (includes context e.g. NetworkMagic)

# Comments

# Checklist

- [X] I've kept this PR simple, on-the-spot, free of cosmetic changes.
- [X] I have reviewed my commit messages and history.
- [X] I've assigned a reviewer.
- [ ] I acknowledge my changes may require an update in the wiki.
- [X ] I have added a reference to this PR to the corresponding issue.

---

- [X] I've checked the checklist