### PR TITLE
Correcting utxo statistics check in the integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ cabal.project.local~
 
 test_keystore.*
 state-integration
+secret.key
+secret.key.lock
+wallet-db-acid/
+wallet-db-sqlite.sqlite3

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -439,12 +439,13 @@ expectWalletUTxO coins = \case
     Left e  -> wantedSuccessButError e
     Right stats -> do
         addr <- liftIO $ generate arbitrary
-        let utxo = Map.fromList $ flip map coins $ \coin ->
-                ( TxInUnknown 0 "arbitrary input"
+        let constructUtxoEntry input coin =
+                ( TxInUnknown input "arbitrary input"
                 , TxOutAux (TxOut addr (mkCoin coin))
                 )
-        computeUtxoStatistics log10 [utxo] `shouldBe` stats
+        let utxo = Map.fromList $ zipWith constructUtxoEntry [0..] coins
 
+        computeUtxoStatistics log10 [utxo] `shouldBe` stats
 
 --
 -- INTERNALS

--- a/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -49,7 +49,7 @@ spec = do
             [ expectWalletUTxO []
             ]
 
-    xscenario "UTxO statistics reflect wallet's activity" $ do
+    scenario "UTxO statistics reflect wallet's activity" $ do
         fixture <- setup $ defaultSetup
             & initialCoins .~ [14, 42, 1337]
 


### PR DESCRIPTION
More stuff in gitignore

# Linked Issue

#143 


# Overview

During integration tests, in the now pending test, the initial setup entails the following coins : ```[14, 42, 1337]```
The computed utxo statistics' check gives one entry of coin between (1000,10000> and no entry of both 14 and 42 coins:
```
HistogramBarCount {bucketUpperBound = 100, bucketCount = 0}
HistogramBarCount {bucketUpperBound = 10000, bucketCount = 1}
theAllStakes = 1337
```
This is in contrast to what is the response from API. Here, each coin finds its place in the respective bucket:
```
HistogramBarCount {bucketUpperBound = 100, bucketCount = 2}
HistogramBarCount {bucketUpperBound = 10000, bucketCount = 1}
and the sum of all coins is calculated as expected:

theAllStakes = 1393
```
The bug was in how the check is determined. The array of pairs **(TxInUnknown 0 "arbitrary input",TxOutAux C)** was used for each coin. This means that when the map was constructed, ONLY the last entry of the list was used when constructing the map. This is because each pair entry held the same "key".

**Solution**:
Make sure "key" is unique and map takes every entry of the list when constructing the map

1. - [x] All integration tests pass and there are no pending ones


# Comments

Use the following command to check:
```
stack test cardano-wallet:test:integration
```

# Checklist

- [x] I've kept this PR simple, on-the-spot, free of cosmetic changes.
- [x] I have reviewed my commit messages and history.
- [x] I've assigned a reviewer.
- [x] I acknowledge my changes may require an update in the wiki.
- [x] I have added a reference to this PR to the corresponding issue.

---

- [x] I've checked the checklist
