### PR TITLE
Fix Metadata Inconsistency After Wallet or Account Deletion

### DIFF
--- a/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
+++ b/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
@@ -24,6 +24,7 @@ openMetaDB fp = do
           closeMetaDB   = withMVar lock ConcreteStorage.closeMetaDB
         , migrateMetaDB = withMVar lock ConcreteStorage.unsafeMigrateMetaDB
         , clearMetaDB   = withMVar lock ConcreteStorage.clearMetaDB
+        , deleteTxMetas = \w a   -> withMVar lock $ \c -> ConcreteStorage.deleteTxMetas c w a
         , getTxMeta     = \t w a -> withMVar lock $ \c -> ConcreteStorage.getTxMeta c t w a
         , putTxMeta     = \ t    -> withMVar lock $ \c -> ConcreteStorage.putTxMeta c t
         , putTxMetaT    = \ t    -> withMVar lock $ \c -> ConcreteStorage.putTxMetaT c t

--- a/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
+++ b/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
@@ -292,6 +292,7 @@ data MetaDBHandle = MetaDBHandle {
       closeMetaDB   :: IO ()
     , migrateMetaDB :: IO ()
     , clearMetaDB   :: IO ()
+    , deleteTxMetas :: Core.Address -> Maybe Word32 -> IO ()
     , getTxMeta     :: Txp.TxId -> Core.Address -> Word32 -> IO (Maybe TxMeta)
     , putTxMeta     :: TxMeta -> IO ()
     , putTxMetaT    :: TxMeta -> IO PutReturn

--- a/test/integration/Test/Integration/Framework/Request.hs
+++ b/test/integration/Test/Integration/Framework/Request.hs
@@ -1,6 +1,7 @@
 module Test.Integration.Framework.Request
     ( HasHttpClient
     , request
+    , request_
     , successfulRequest
     , ($-)
     ) where
@@ -27,6 +28,14 @@ class Request originalResponse where
         :: forall m ctx. (MonadIO m, MonadReader ctx m, HasHttpClient ctx)
         => (WalletClient IO -> IO (Either ClientError originalResponse))
         -> m (Either ClientError (Response originalResponse))
+
+    -- | Run a given request and discard the response
+    request_
+        :: forall m ctx. (MonadIO m, MonadReader ctx m, HasHttpClient ctx)
+        => (WalletClient IO -> IO (Either ClientError originalResponse))
+        -> m ()
+    request_ =
+        void . request
 
     -- | Run a given request as above, but throws if it fails
     successfulRequest


### PR DESCRIPTION
# Linked Issue

<Put here a reference to the issue this PR relates to and which requirements it tackles>

<p align="right">#141</p>


# Overview

<Detail in a few bullet points the work accomplished in this PR>

- [x]  It discards incoherent transactions fetched from the DB, if any, and shout a warning in the log.This is in order to make the system more resilient to concurrent calls while a wallet or account is being deleted (since metadata and accounts / wallets are stored in separated databases, we can't easily run both delete in a single transaction).

- [x] It deletes corresponding metadata when an account or a wallet is removed. This may cause extra damage? What if there are pending transactions when we delete the account or wallet.

- [x] It now ignores insertion violations thay may occur if a user restore a deleted wallet or account. Cleaning up the metadata table itself isn't sufficient; we also need (in theory) to cleanup the corresponding inputs and outputs though in practice, this isn't that simple. Inputs may be used by different tx. Ideally, we would rely on db foreign keys for that but `beam` (the library we use to talk to SQLite) doesn't support them... Therefore, dust remains in the DB after deletion which is acceptable for now.

- [x] It adds a few regression integration scenarios to illustrate the various fixes.


# Comments

<Additional comments or screenshots to attach if any>

This is actually a port of [cardano-sl#3943](https://github.com/input-output-hk/cardano-sl/pull/3943) already reviewed and discussed with Kostas.


# Checklist

- [x] I've kept this PR simple, on-the-spot, free of cosmetic changes.
- [x] I have reviewed my commit messages and history.
- [x] I've assigned a reviewer.
- [x] I acknowledge my changes may require an update in the wiki.
- [x] I have added a reference to this PR to the corresponding issue.

---

- [x] I've checked the checklist
