### PR TITLE
Remove V1 wrapper: InputSelectionPolicy

### DIFF
--- a/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
+++ b/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
@@ -49,7 +49,7 @@ newTransaction aw payment@Payment{..} = liftIO $ do
 
     -- NOTE(adn) The 'SenderPaysFee' option will become configurable as part
     -- of CBR-291.
-    let inputGrouping = toInputGrouping $ fromMaybe (V1 defaultInputSelectionPolicy)
+    let inputGrouping = toInputGrouping $ fromMaybe (WalletInputSelectionPolicy defaultInputSelectionPolicy)
                                                     pmtGroupingPolicy
     res <- liftIO $ (WalletLayer.pay aw) (maybe mempty coerce pmtSpendingPassword)
                                          inputGrouping
@@ -91,7 +91,7 @@ estimateFees :: ActiveWalletLayer IO
              -> Payment
              -> Handler (APIResponse EstimatedFees)
 estimateFees aw payment@Payment{..} = do
-    let inputGrouping = toInputGrouping $ fromMaybe (V1 defaultInputSelectionPolicy)
+    let inputGrouping = toInputGrouping $ fromMaybe (WalletInputSelectionPolicy defaultInputSelectionPolicy)
                                                     pmtGroupingPolicy
     res <- liftIO $ (WalletLayer.estimateFees aw) inputGrouping
                                                   SenderPaysFee

--- a/src/Cardano/Wallet/API/WIP/Handlers.hs
+++ b/src/Cardano/Wallet/API/WIP/Handlers.hs
@@ -53,7 +53,7 @@ newUnsignedTransaction :: ActiveWalletLayer IO
                        -> Payment
                        -> Handler (APIResponse UnsignedTransaction)
 newUnsignedTransaction aw payment@Payment{..} = do
-    let inputGrouping = toInputGrouping $ fromMaybe (V1 defaultInputSelectionPolicy)
+    let inputGrouping = toInputGrouping $ fromMaybe (WalletInputSelectionPolicy defaultInputSelectionPolicy)
                                                     pmtGroupingPolicy
     res <- liftIO $ (WalletLayer.createUnsignedTx aw) inputGrouping
                                                       SenderPaysFee

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -267,7 +267,7 @@ toSyncState = \case
              }
 
 -- Matches the input InputGroupingPolicy with the Kernel's 'InputGrouping'
-toInputGrouping :: V1 InputSelectionPolicy -> InputGrouping
-toInputGrouping (V1 policy) = case policy of
+toInputGrouping :: V1.WalletInputSelectionPolicy -> InputGrouping
+toInputGrouping (V1.WalletInputSelectionPolicy policy) = case policy of
     OptimizeForSecurity       -> PreferGrouping
     OptimizeForHighThroughput -> IgnoreGrouping

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -24,7 +24,6 @@ module Test.Integration.Framework.DSL
     , Redemption (..)
     , WalletUpdate(..)
     , ShieldedRedemptionCode (..)
-    , InputSelectionPolicy(..)
     , FilterOperations(..)
     , SortOperations(..)
     , WalletOperation(..)
@@ -90,7 +89,6 @@ import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.Client.Http (ClientError (..), WalletClient)
 import qualified Cardano.Wallet.Client.Http as Client
 import           Pos.Chain.Txp (TxIn (..), TxOut (..), TxOutAux (..))
-import           Pos.Client.Txp (InputSelectionPolicy (..))
 import           Pos.Core (Coin, IsBootstrapEraAddr (..), deriveLvl2KeyPair,
                      mkCoin, unsafeGetCoin)
 import           Pos.Core.NetworkMagic (NetworkMagic (..))
@@ -205,7 +203,7 @@ defaultDistribution
 defaultDistribution c s = pure $
     PaymentDistribution (V1 $ head $ s ^. typed) (V1 $ mkCoin c)
 
-defaultGroupingPolicy :: Maybe (V1 InputSelectionPolicy)
+defaultGroupingPolicy :: Maybe WalletInputSelectionPolicy
 defaultGroupingPolicy = Nothing
 
 defaultPage :: Maybe Page

--- a/test/unit/API/MarshallingSpec.hs
+++ b/test/unit/API/MarshallingSpec.hs
@@ -14,7 +14,6 @@ import           Data.Time (UTCTime (..), fromGregorian)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Typeable (typeRep)
 import           Data.Version (Version)
-import           Pos.Client.Txp.Util (InputSelectionPolicy)
 import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto as Crypto
 import           Servant.API (FromHttpApiData (..), ToHttpApiData (..))
@@ -63,7 +62,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @NewAddress Proxy
         aesonRoundtripProp @(V1 Core.Coin) Proxy
         aesonRoundtripProp @WalletPassPhrase Proxy
-        aesonRoundtripProp @(V1 InputSelectionPolicy) Proxy
+        aesonRoundtripProp @WalletInputSelectionPolicy Proxy
         aesonRoundtripProp @TimeInfo Proxy
         aesonRoundtripProp @Transaction Proxy
         aesonRoundtripProp @WalletTimestamp Proxy

--- a/test/unit/Golden/APIV1Types.hs
+++ b/test/unit/Golden/APIV1Types.hs
@@ -7,10 +7,10 @@ import           Universum
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Cardano.Wallet.API.V1.Types (V1 (..), WalletPassPhrase (..),
-                     WalletTimestamp (..))
-import           Pos.Core (Timestamp, parseTimestamp)
+import           Cardano.Wallet.API.V1.Types (WalletInputSelectionPolicy (..),
+                     WalletPassPhrase (..), WalletTimestamp (..))
 import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
+import           Pos.Core (Timestamp, parseTimestamp)
 
 import           Pos.Crypto (PassPhrase (..))
 
@@ -43,13 +43,13 @@ golden_WalletTimestamp =
 golden_WalletInputSelectionPolicy1 :: Property
 golden_WalletInputSelectionPolicy1 =
     goldenTestJSON
-        (V1 OptimizeForSecurity)
+        (WalletInputSelectionPolicy OptimizeForSecurity)
         "test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy1"
 
 golden_WalletInputSelectionPolicy2 :: Property
 golden_WalletInputSelectionPolicy2 =
     goldenTestJSON
-        (V1 OptimizeForHighThroughput)
+        (WalletInputSelectionPolicy OptimizeForHighThroughput)
         "test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy2"
 
 -------------------------------------------------------------------------------

--- a/test/unit/Golden/APIV1Types.hs
+++ b/test/unit/Golden/APIV1Types.hs
@@ -7,9 +7,11 @@ import           Universum
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Cardano.Wallet.API.V1.Types (WalletPassPhrase (..),
+import           Cardano.Wallet.API.V1.Types (V1 (..), WalletPassPhrase (..),
                      WalletTimestamp (..))
 import           Pos.Core (Timestamp, parseTimestamp)
+import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
+
 import           Pos.Crypto (PassPhrase (..))
 
 import           Test.Pos.Util.Golden (discoverGolden, goldenTestJSON)
@@ -37,6 +39,18 @@ golden_WalletTimestamp =
     goldenTestJSON
         (WalletTimestamp exampleTimestamp)
         "test/unit/Golden/golden/apiV1Types/json/Timestamp"
+
+golden_WalletInputSelectionPolicy1 :: Property
+golden_WalletInputSelectionPolicy1 =
+    goldenTestJSON
+        (V1 OptimizeForSecurity)
+        "test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy1"
+
+golden_WalletInputSelectionPolicy2 :: Property
+golden_WalletInputSelectionPolicy2 =
+    goldenTestJSON
+        (V1 OptimizeForHighThroughput)
+        "test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy2"
 
 -------------------------------------------------------------------------------
 -- Examples

--- a/test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy1
+++ b/test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy1
@@ -1,0 +1,1 @@
+"OptimizeForSecurity"

--- a/test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy2
+++ b/test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy2
@@ -1,0 +1,1 @@
+"OptimizeForHighThroughput"


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#119</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `InputSelectionPolicy` doesn't use `V1` wrapper anymore.
- [x] `InputSelectionPolicy` golden test passes for old and new versions.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
