### PR TITLE
Remove V1 wrapper: Address

### DIFF
--- a/src/Cardano/Wallet/API/Indices.hs
+++ b/src/Cardano/Wallet/API/Indices.hs
@@ -62,8 +62,8 @@ instance ToIndex Transaction WalletTimestamp where
     toIndex _ = fmap WalletTimestamp . Core.parseTimestamp
     accessIx Transaction{..} = txCreationTime
 
-instance ToIndex WalletAddress (V1 Core.Address) where
-    toIndex _ = fmap V1 . either (const Nothing) Just . Core.decodeTextAddress
+instance ToIndex WalletAddress WalAddress where
+    toIndex _ = fmap WalAddress . either (const Nothing) Just . Core.decodeTextAddress
     accessIx WalletAddress{..} = addrId
 
 --
@@ -83,7 +83,7 @@ instance HasPrimKey Transaction where
     primKey = txId
 
 instance HasPrimKey WalletAddress where
-    type PrimKey WalletAddress = V1 Core.Address
+    type PrimKey WalletAddress = WalAddress
     primKey = addrId
 
 -- | The secondary indices for each major resource.
@@ -139,7 +139,7 @@ type family IndexToQueryParam resource ix where
     IndexToQueryParam Wallet  WalletId                = "id"
     IndexToQueryParam Wallet  WalletTimestamp         = "created_at"
 
-    IndexToQueryParam WalletAddress (V1 Core.Address) = "address"
+    IndexToQueryParam WalletAddress (WalAddress)      = "address"
 
     IndexToQueryParam Transaction (V1 Txp.TxId)      = "id"
     IndexToQueryParam Transaction WalletTimestamp    = "created_at"
@@ -168,6 +168,6 @@ instance KnownQueryParam Account AccountIndex
 instance KnownQueryParam Wallet Core.Coin
 instance KnownQueryParam Wallet WalletId
 instance KnownQueryParam Wallet WalletTimestamp
-instance KnownQueryParam WalletAddress (V1 Core.Address)
+instance KnownQueryParam WalletAddress WalAddress
 instance KnownQueryParam Transaction (V1 Txp.TxId)
 instance KnownQueryParam Transaction WalletTimestamp

--- a/src/Cardano/Wallet/API/V1/Accounts.hs
+++ b/src/Cardano/Wallet/API/V1/Accounts.hs
@@ -8,8 +8,6 @@ import           Cardano.Wallet.API.Types
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Types
 
-import qualified Pos.Core as Core
-
 
 type API
     = Tags '["Accounts"] :>
@@ -38,7 +36,7 @@ type API
           :> CaptureAccountId :> "addresses"
           :> Summary "Retrieve only account's addresses."
           :> WalletRequestParams
-          :> FilterBy '[V1 Core.Address] WalletAddress
+          :> FilterBy '[WalAddress] WalletAddress
           :> Get '[ValidJSON] (APIResponse AccountAddresses)
     :<|> "wallets" :> CaptureWalletId :> "accounts"
           :> CaptureAccountId :> "amount"

--- a/src/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/src/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -85,7 +85,7 @@ getAccountAddresses
     -> WalletId
     -> AccountIndex
     -> RequestParams
-    -> FilterOperations '[V1 Address] WalletAddress
+    -> FilterOperations '[WalAddress] WalletAddress
     -> Handler (APIResponse AccountAddresses)
 getAccountAddresses layer wId accIdx pagination filters = do
     -- NOTE: Many of the Servant handlers have the following structure:

--- a/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
+++ b/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
@@ -18,7 +18,6 @@ import           Data.Coerce (coerce)
 
 import           Pos.Chain.Txp (TxId)
 import           Pos.Client.Txp.Util (defaultInputSelectionPolicy)
-import           Pos.Core (Address)
 
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
@@ -73,7 +72,7 @@ txFromMeta aw embedErr meta = do
 getTransactionsHistory :: PassiveWalletLayer IO
                        -> Maybe WalletId
                        -> Maybe AccountIndex
-                       -> Maybe (V1 Address)
+                       -> Maybe WalAddress
                        -> RequestParams
                        -> FilterOperations '[V1 TxId, WalletTimestamp] Transaction
                        -> SortOperations Transaction

--- a/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -14,7 +14,6 @@ import           Universum
 import qualified Data.Char as C
 import           Pos.Core (decodeTextAddress)
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
@@ -274,7 +273,7 @@ newTransactionError e = case e of
           ex@(CoinSelHardErrOutputIsRedeemAddress addr) ->
                 case (decodeTextAddress addr) of
                     Right addr' ->
-                        V1.OutputIsRedeem (V1 addr')
+                        V1.OutputIsRedeem (V1.WalAddress addr')
                     Left _ ->
                         V1.UnknownError $ (sformat build ex)
 
@@ -297,11 +296,11 @@ newTransactionError e = case e of
 
     (Kernel.NewTransactionErrorSignTxFailed e') -> case e' of
         (Kernel.SignTransactionMissingKey addr) ->
-            V1.TxSafeSignerNotFound (V1 addr)
+            V1.TxSafeSignerNotFound (V1.WalAddress addr)
         (Kernel.SignTransactionErrorUnknownAddress _addr) ->
             V1.AddressNotFound
         (Kernel.SignTransactionErrorNotOwned addr) ->
-            V1.TxSafeSignerNotFound (V1 addr)
+            V1.TxSafeSignerNotFound (V1.WalAddress addr)
 
     Kernel.NewTransactionInvalidTxIn ->
             V1.SignedTxSubmitError "NewTransactionInvalidTxIn"

--- a/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -262,7 +262,7 @@ instance ToParamSchema Core.Address where
   toParamSchema _ = mempty
     & type_ .~ SwaggerString
 
-instance ToParamSchema (V1 Core.Address) where
+instance ToParamSchema WalAddress where
   toParamSchema _ = toParamSchema (Proxy @Core.Address)
 
 
@@ -345,7 +345,7 @@ $errors
     , inlineCodeBlock (T.decodeUtf8 $ BL.toStrict $ encodePretty err)
     ]
 
-  sampleAddress = V1 Core.Address
+  sampleAddress = WalAddress Core.Address
       { Core.addrRoot =
           Crypto.unsafeAbstractHash ("asdfasdf" :: String)
       , Core.addrAttributes =

--- a/src/Cardano/Wallet/API/V1/Transactions.hs
+++ b/src/Cardano/Wallet/API/V1/Transactions.hs
@@ -6,7 +6,6 @@ import           Cardano.Wallet.API.Types
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Types
 import qualified Pos.Chain.Txp as Txp
-import qualified Pos.Core as Core
 
 import           Servant
 
@@ -17,7 +16,7 @@ type API = Tags '["Transactions"] :>
     :<|> "transactions" :> Summary "Returns the transaction history, i.e the list of all the past transactions."
                         :> QueryParam "wallet_id" WalletId
                         :> QueryParam "account_index" AccountIndex
-                        :> QueryParam "address" (V1 Core.Address)
+                        :> QueryParam "address" (WalAddress)
                         :> WalletRequestParams
                         :> FilterBy '[ V1 Txp.TxId
                                      , WalletTimestamp

--- a/src/Cardano/Wallet/Client.hs
+++ b/src/Cardano/Wallet/Client.hs
@@ -121,7 +121,7 @@ data WalletClient m
          -> AccountIndex
          -> Maybe Page
          -> Maybe PerPage
-         -> FilterOperations '[V1 Address] WalletAddress
+         -> FilterOperations '[WalAddress] WalletAddress
          -> Resp m AccountAddresses
     , getAccountBalance
          :: WalletId -> AccountIndex -> Resp m AccountBalance
@@ -131,7 +131,7 @@ data WalletClient m
     , getTransactionIndexFilterSorts
          :: Maybe WalletId
          -> Maybe AccountIndex
-         -> Maybe (V1 Core.Address)
+         -> Maybe WalAddress
          -> Maybe Page
          -> Maybe PerPage
          -> FilterOperations '[V1 Core.TxId, WalletTimestamp] Transaction
@@ -212,7 +212,7 @@ getTransactionIndex
     => WalletClient m
     -> Maybe WalletId
     -> Maybe AccountIndex
-    -> Maybe (V1 Core.Address)
+    -> Maybe WalAddress
     -> Resp m [Transaction]
 getTransactionIndex wc wid maid maddr =
     paginateAll $ \mp mpp -> getTransactionIndexFilterSorts wc wid maid maddr mp mpp NoFilters NoSorts

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -116,7 +116,7 @@ import           Pos.Core.Chrono (NewestFirst (..))
 import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto as Core
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Cardano.Wallet.API.V1.Types (WalAddress (..))
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Spec
@@ -590,7 +590,7 @@ instance HasPrimKey (Indexed HdAddress) where
 
 type SecondaryHdRootIxs           = '[]
 type SecondaryHdAccountIxs        = '[HdRootId]
-type SecondaryIndexedHdAddressIxs = '[AutoIncrementKey, HdRootId, HdAccountId, V1 Core.Address]
+type SecondaryIndexedHdAddressIxs = '[AutoIncrementKey, HdRootId, HdAccountId, WalAddress]
 
 type instance IndicesOf HdRoot              = SecondaryHdRootIxs
 type instance IndicesOf HdAccount           = SecondaryHdAccountIxs
@@ -611,7 +611,7 @@ instance IxSet.Indexable (HdAddressId ': SecondaryIndexedHdAddressIxs)
                 (ixFun ((:[]) . view ixedIndex))
                 (ixFun ((:[]) . view (ixedIndexed . hdAddressRootId)))
                 (ixFun ((:[]) . view (ixedIndexed . hdAddressAccountId)))
-                (ixFun ((:[]) . V1 . view (ixedIndexed . hdAddressAddress . fromDb)))
+                (ixFun ((:[]) . WalAddress . view (ixedIndexed . hdAddressAddress . fromDb)))
 
 {-------------------------------------------------------------------------------
   Top-level HD wallet structure
@@ -690,7 +690,7 @@ zoomHdCardanoAddress embedErr addr =
     findAddress :: Query' e HdWallets HdAddress
     findAddress = do
         addresses <- view hdWalletsAddresses
-        maybe err return $ (fmap _ixedIndexed $ getOne $ getEQ (V1 addr) addresses)
+        maybe err return $ (fmap _ixedIndexed $ getOne $ getEQ (WalAddress addr) addresses)
 
     err :: Query' e HdWallets x
     err = missing $ embedErr (UnknownHdCardanoAddress addr)

--- a/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 import qualified Pos.Chain.Txp as Core
 import qualified Pos.Core as Core
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Cardano.Wallet.API.V1.Types (WalAddress (..))
 import           Cardano.Wallet.Kernel.DB.BlockMeta (blockMetaSlotId,
                      localBlockMeta)
 import           Cardano.Wallet.Kernel.DB.HdWallet
@@ -72,7 +72,7 @@ cpChange ours cp =
       (Pending.change ours' $ cp ^. cpForeign)
   where
     ours' :: Core.Address -> Bool
-    ours' addr = IxSet.size (IxSet.getEQ (V1 addr) ours) == 1
+    ours' addr = IxSet.size (IxSet.getEQ (WalAddress addr) ours) == 1
 
 -- | Total balance (available balance plus change)
 cpTotalBalance :: IsCheckpoint c => IxSet (Indexed HdAddress) -> c -> Core.Coin

--- a/src/Cardano/Wallet/Kernel/Decrypt.hs
+++ b/src/Cardano/Wallet/Kernel/Decrypt.hs
@@ -58,5 +58,5 @@ decryptAddress (hdPass, wCId) addr = do
     hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
     derPath <- unpackHDAddressAttr hdPass hdPayload
     case derPath of
-        [a,b] -> Just $ WAddressMeta wCId a b (V1 addr)
+        [a,b] -> Just $ WAddressMeta wCId a b (V1.WalAddress addr)
         _     -> Nothing

--- a/src/Cardano/Wallet/WalletLayer.hs
+++ b/src/Cardano/Wallet/WalletLayer.hs
@@ -39,7 +39,7 @@ import           Pos.Chain.Block (Blund)
 import           Pos.Chain.Txp (Tx, TxId, Utxo)
 import           Pos.Chain.Update (ConfirmedProposalState, SoftwareVersion)
 import           Pos.Core (Coin)
-import qualified Pos.Core as Core (Address)
+import qualified Pos.Core as Core
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
 import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase)
@@ -49,12 +49,12 @@ import           Cardano.Wallet.API.Request.Filter (FilterOperations (..))
 import           Cardano.Wallet.API.Request.Sort (SortOperations (..))
 import           Cardano.Wallet.API.Response (APIResponse, SliceOf (..))
 import           Cardano.Wallet.API.V1.Types (Account, AccountBalance,
-                     AccountIndex, AccountUpdate, Address, EosWallet,
-                     EosWalletId, ForceNtpCheck, NewAccount, NewAddress,
-                     NewEosWallet, NewWallet, NodeInfo, NodeSettings,
-                     PasswordUpdate, Payment, Redemption, SignedTransaction,
-                     SpendingPassword, Transaction, UnsignedTransaction,
-                     V1 (..), Wallet, WalletAddress, WalletId, WalletImport,
+                     AccountIndex, AccountUpdate, EosWallet, EosWalletId,
+                     ForceNtpCheck, NewAccount, NewAddress, NewEosWallet,
+                     NewWallet, NodeInfo, NodeSettings, PasswordUpdate,
+                     Payment, Redemption, SignedTransaction, SpendingPassword,
+                     Transaction, UnsignedTransaction, V1 (..), WalAddress,
+                     Wallet, WalletAddress, WalletId, WalletImport,
                      WalletTimestamp, WalletUpdate)
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
@@ -451,7 +451,7 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , getAccountAddresses  :: WalletId
                            -> AccountIndex
                            -> RequestParams
-                           -> FilterOperations '[V1 Address] WalletAddress
+                           -> FilterOperations '[WalAddress] WalletAddress
                            -> m (Either GetAccountError (APIResponse [WalletAddress]))
     , updateAccount        :: WalletId
                            -> AccountIndex
@@ -470,7 +470,7 @@ data PassiveWalletLayer m = PassiveWalletLayer
     -- transactions
     , getTransactions      :: Maybe WalletId
                            -> Maybe AccountIndex
-                           -> Maybe (V1 Address)
+                           -> Maybe (WalAddress)
                            -> RequestParams
                            -> FilterOperations '[V1 TxId, WalletTimestamp] Transaction
                            -> SortOperations Transaction

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
@@ -150,7 +150,7 @@ updateAccount wallet wId accIx (V1.AccountUpdate newName) = runExceptT $ do
 getAccountAddresses :: V1.WalletId
                     -> V1.AccountIndex
                     -> RequestParams
-                    -> FilterOperations '[V1 Core.Address] WalletAddress
+                    -> FilterOperations '[V1.WalAddress] WalletAddress
                     -> Kernel.DB
                     -> Either GetAccountError (APIResponse [V1.WalletAddress])
 getAccountAddresses wId accIx rp fo snapshot = runExcept $ do
@@ -166,8 +166,8 @@ getAccountAddresses wId accIx rp fo snapshot = runExcept $ do
   Auxiliary
 -------------------------------------------------------------------------------}
 
-filterHdAddress :: FilterOperations '[V1 Core.Address] WalletAddress
-                -> FilterOperations '[V1 Core.Address] (Indexed HD.HdAddress)
+filterHdAddress :: FilterOperations '[V1.WalAddress] WalletAddress
+                -> FilterOperations '[V1.WalAddress] (Indexed HD.HdAddress)
 filterHdAddress NoFilters               = NoFilters
 filterHdAddress (FilterNop NoFilters)   = FilterNop NoFilters
 filterHdAddress (FilterOp op NoFilters) = FilterOp (coerce op) NoFilters

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
@@ -51,7 +51,7 @@ createAddress wallet
     -- | Creates a new 'WalletAddress'. As this is a brand new, fresh Address,
     -- it's fine to have 'False' for both 'isUsed' and 'isChange'.
     mkAddress :: Address -> WalletAddress
-    mkAddress addr = WalletAddress (V1 addr) False False (V1 V1.AddressIsOurs)
+    mkAddress addr = WalletAddress (V1.WalAddress addr) False False (V1 V1.AddressIsOurs)
 
 
 
@@ -181,7 +181,7 @@ validateAddress rawText db = runExcept $ do
         -- another instance of the same wallet of course), or it may be that
         -- it's not even ours. In both cases we return 'V1.AddressAmbiguousOwnership'.
         return V1.WalletAddress {
-            addrId            = V1 cardanoAddress
+            addrId            = V1.WalAddress cardanoAddress
           , addrUsed          = False
           , addrChangeAddress = False
           , addrOwnership     = (V1 V1.AddressAmbiguousOwnership)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -194,7 +194,7 @@ toAssuranceLevel HD.AssuranceLevelStrict = V1.StrictAssurance
 -- | Converts a Kernel 'HdAddress' into a V1 'WalletAddress'.
 toAddress :: HD.HdAccount -> HD.HdAddress -> V1.WalletAddress
 toAddress acc hdAddress =
-    V1.WalletAddress (V1 cardanoAddress)
+    V1.WalletAddress (V1.WalAddress cardanoAddress)
                      (addressMeta ^. addressMetaIsUsed)
                      (addressMeta ^. addressMetaIsChange)
                      (V1 addressOwnership)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -38,7 +38,7 @@ getTransactions :: MonadIO m
                 => Kernel.PassiveWallet
                 -> Maybe V1.WalletId
                 -> Maybe V1.AccountIndex
-                -> Maybe (V1 Address)
+                -> Maybe V1.WalAddress
                 -> RequestParams
                 -> FilterOperations '[V1 TxId, V1.WalletTimestamp] V1.Transaction
                 -> SortOperations V1.Transaction
@@ -68,7 +68,7 @@ getTransactions wallet mbWalletId mbAccountIndex mbAddress params fop sop = lift
                 (TxMeta.Offset . fromIntegral $ (cp - 1) * pp)
                 (TxMeta.Limit . fromIntegral $ pp)
                 accountFops
-                (unV1 <$> mbAddress)
+                (V1.unWalAddress <$> mbAddress)
                 (castFiltering $ mapIx unV1 <$> F.findMatchingFilterOp fop)
                 (castFiltering $ mapIx unV1 <$> F.findMatchingFilterOp fop)
                 mbSorting
@@ -171,10 +171,10 @@ metaToTx db slotCount current TxMeta{..} = do
             hdAccountId = HD.HdAccountId hdRootId (HD.HdAccountIx _txMetaAccountIx)
 
             inputsToPayDistr :: (a , b, Address, Coin) -> V1.PaymentDistribution
-            inputsToPayDistr (_, _, addr, c) = V1.PaymentDistribution (V1 addr) (V1 c)
+            inputsToPayDistr (_, _, addr, c) = V1.PaymentDistribution (V1.WalAddress addr) (V1 c)
 
             outputsToPayDistr :: (Address, Coin) -> V1.PaymentDistribution
-            outputsToPayDistr (addr, c) = V1.PaymentDistribution (V1 addr) (V1 c)
+            outputsToPayDistr (addr, c) = V1.PaymentDistribution (V1.WalAddress addr) (V1 c)
 
 buildDynamicTxMeta :: HD.AssuranceLevel -> SlotCount -> HD.CombinedWithAccountState (Maybe SlotId) -> SlotId -> Bool -> (V1.TransactionStatus, Word64)
 buildDynamicTxMeta assuranceLevel slotCount mSlotwithState currentSlot isPending =

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -201,7 +201,7 @@ defaultDistribution
     -> s
     -> NonEmpty PaymentDistribution
 defaultDistribution c s = pure $
-    PaymentDistribution (V1 $ head $ s ^. typed) (V1 $ mkCoin c)
+    PaymentDistribution (WalAddress $ head $ s ^. typed) (V1 $ mkCoin c)
 
 defaultGroupingPolicy :: Maybe WalletInputSelectionPolicy
 defaultGroupingPolicy = Nothing

--- a/test/unit/API/MarshallingSpec.hs
+++ b/test/unit/API/MarshallingSpec.hs
@@ -92,7 +92,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
         httpApiDataRoundtripProp @(V1 Txp.TxId) Proxy
         httpApiDataRoundtripProp @WalletId Proxy
         httpApiDataRoundtripProp @WalletTimestamp Proxy
-        httpApiDataRoundtripProp @(V1 Core.Address) Proxy
+        httpApiDataRoundtripProp @WalAddress Proxy
         httpApiDataRoundtripProp @PerPage Proxy
         httpApiDataRoundtripProp @Page Proxy
         httpApiDataRoundtripProp @Core.Coin Proxy

--- a/test/unit/Golden/APIV1Types.hs
+++ b/test/unit/Golden/APIV1Types.hs
@@ -7,7 +7,7 @@ import           Universum
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Cardano.Wallet.API.V1.Types (V1 (..),
+import           Cardano.Wallet.API.V1.Types (WalAddress (..),
                      WalletInputSelectionPolicy (..), WalletPassPhrase (..),
                      WalletTimestamp (..))
 import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
@@ -57,13 +57,13 @@ golden_WalletInputSelectionPolicy2 =
 golden_WalletAddress1 :: Property
 golden_WalletAddress1 =
     goldenTestJSON
-        (V1 exampleAddress1)
+        (WalAddress exampleAddress1)
         "test/unit/Golden/golden/apiV1Types/json/Address1"
 
 golden_WalletAddress2 :: Property
 golden_WalletAddress2 =
     goldenTestJSON
-        (V1 exampleAddress2)
+        (WalAddress exampleAddress2)
         "test/unit/Golden/golden/apiV1Types/json/Address2"
 
 -------------------------------------------------------------------------------

--- a/test/unit/Golden/APIV1Types.hs
+++ b/test/unit/Golden/APIV1Types.hs
@@ -7,10 +7,12 @@ import           Universum
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Cardano.Wallet.API.V1.Types (WalletInputSelectionPolicy (..),
-                     WalletPassPhrase (..), WalletTimestamp (..))
+import           Cardano.Wallet.API.V1.Types (V1 (..),
+                     WalletInputSelectionPolicy (..), WalletPassPhrase (..),
+                     WalletTimestamp (..))
 import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
-import           Pos.Core (Timestamp, parseTimestamp)
+import           Pos.Core (Address, Timestamp, decodeTextAddress,
+                     parseTimestamp)
 
 import           Pos.Crypto (PassPhrase (..))
 
@@ -52,6 +54,18 @@ golden_WalletInputSelectionPolicy2 =
         (WalletInputSelectionPolicy OptimizeForHighThroughput)
         "test/unit/Golden/golden/apiV1Types/json/InputSelectionPolicy2"
 
+golden_WalletAddress1 :: Property
+golden_WalletAddress1 =
+    goldenTestJSON
+        (V1 exampleAddress1)
+        "test/unit/Golden/golden/apiV1Types/json/Address1"
+
+golden_WalletAddress2 :: Property
+golden_WalletAddress2 =
+    goldenTestJSON
+        (V1 exampleAddress2)
+        "test/unit/Golden/golden/apiV1Types/json/Address2"
+
 -------------------------------------------------------------------------------
 -- Examples
 -------------------------------------------------------------------------------
@@ -64,3 +78,13 @@ exampleTimestamp :: Timestamp
 exampleTimestamp = timestamp
   where
     Just timestamp = parseTimestamp "2018-12-11T08:09:10"
+
+exampleAddress1 :: Address
+exampleAddress1 = address
+  where
+    Right address = decodeTextAddress "Ae2tdPwUPEZD3PkAcijLa9MP5Juyq6if6k2Xo1dqyvGm4cs6PkZiKrTrSZE"
+
+exampleAddress2 :: Address
+exampleAddress2 = address
+  where
+    Right address = decodeTextAddress "DdzFFzCqrhshvqztiAaVUuKkZWMepHt2oG1YoTxTt2cgyfaTFSnniFe55u5enazUEf77WDA5EC1gNErvtH7egHL8YZFqj2y4x3dm4hFa"

--- a/test/unit/Golden/WalletError.hs
+++ b/test/unit/Golden/WalletError.hs
@@ -9,8 +9,8 @@ import           Hedgehog (Property)
 import           Cardano.Wallet.API.Response (JSONValidationError (..),
                      UnsupportedMimeTypeError (..))
 import           Cardano.Wallet.API.V1.Swagger.Example (genExample)
-import           Cardano.Wallet.API.V1.Types (ErrNotEnoughMoney (..), V1 (..),
-                     WalletError (..), exampleWalletId)
+import           Cardano.Wallet.API.V1.Types (ErrNotEnoughMoney (..),
+                     WalAddress (..), WalletError (..), exampleWalletId)
 
 import           Test.Pos.Core.ExampleHelpers (exampleAddress)
 import           Test.Pos.Util.Golden (discoverGolden, goldenTestJSON)
@@ -46,7 +46,7 @@ golden_WalletError_NotEnoughMoneyCannotCoverFee =
 golden_WalletError_OutputIsRedeem :: Property
 golden_WalletError_OutputIsRedeem =
     goldenTestJSON
-        (OutputIsRedeem $ V1 exampleAddress)
+        (OutputIsRedeem $ WalAddress exampleAddress)
             "test/unit/Golden/golden/WalletError_OutputIsRedeem"
 
 golden_WalletError_UnknownError :: Property
@@ -118,7 +118,7 @@ golden_WalletError_TxRedemptionDepleted =
 golden_WalletError_TxSafeSignerNotFound :: Property
 golden_WalletError_TxSafeSignerNotFound =
     goldenTestJSON
-        (TxSafeSignerNotFound $ V1 exampleAddress)
+        (TxSafeSignerNotFound $ WalAddress exampleAddress)
             "test/unit/Golden/golden/WalletError_TxSafeSignerNotFound"
 
 golden_WalletError_MissingRequiredParams :: Property

--- a/test/unit/Golden/golden/apiV1Types/json/Address1
+++ b/test/unit/Golden/golden/apiV1Types/json/Address1
@@ -1,0 +1,1 @@
+"Ae2tdPwUPEZD3PkAcijLa9MP5Juyq6if6k2Xo1dqyvGm4cs6PkZiKrTrSZE"

--- a/test/unit/Golden/golden/apiV1Types/json/Address2
+++ b/test/unit/Golden/golden/apiV1Types/json/Address2
@@ -1,0 +1,1 @@
+"DdzFFzCqrhshvqztiAaVUuKkZWMepHt2oG1YoTxTt2cgyfaTFSnniFe55u5enazUEf77WDA5EC1gNErvtH7egHL8YZFqj2y4x3dm4hFa"

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -420,7 +420,7 @@ spec = describe "Addresses" $ do
                         pure (toBeCheckedAddresses === correctAddresses)
 
         describe "Address listing with multiple Accounts (Servant)" $ do
-            let rootId = addrRoot . V1.unV1 . V1.addrId
+            let rootId = addrRoot . V1.unWalAddress . V1.addrId
             prop "page 0, per page 0" $ withMaxSuccess 5 $ do
                 monadicIO $ do
                     pm <- pick arbitrary
@@ -543,7 +543,7 @@ spec = describe "Addresses" $ do
                     pm <- pick arbitrary
                     withAddressFixtures pm 1 $ \_ layer _ [af] -> do
                         res <- WalletLayer.validateAddress layer
-                            (sformat build (V1.unV1 $ V1.addrId $ addressFixtureAddress af))
+                            (sformat build (V1.unWalAddress $ V1.addrId $ addressFixtureAddress af))
                         bimap STB STB res `shouldSatisfy` isRight
 
             prop "rejects a malformed address" $ withMaxSuccess 5 $
@@ -562,7 +562,7 @@ spec = describe "Addresses" $ do
                     pm                      <- pick arbitrary
                     let expected :: V1.WalletAddress
                         expected = V1.WalletAddress {
-                            addrId            = V1.V1 randomAddr
+                            addrId            = V1.WalAddress randomAddr
                           , addrUsed          = False
                           , addrChangeAddress = False
                           , addrOwnership     = V1.V1 V1.AddressAmbiguousOwnership

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -230,7 +230,7 @@ getFixedAddress layer Fix{..} = do
             filters
     -- the defaut account of the wallet should have a unique address.
     let [address] = wrData wr
-    return $ V1.unV1 . V1.addrId $ address
+    return $ V1.unWalAddress . V1.addrId $ address
 
 -- | Returns an address from the account we explicitely create.
 getNonFixedAddress :: WalletLayer.ActiveWalletLayer IO -> Fix -> IO Core.Address
@@ -246,7 +246,7 @@ getNonFixedAddress layer Fix{..} = do
             filters
     -- the account we create in the fixture should also have an address
     let (address : _) = wrData wr
-    return $ V1.unV1 . V1.addrId $ address
+    return $ V1.unWalAddress . V1.addrId $ address
 
 getAccountBalanceNow :: Kernel.PassiveWallet -> Fix -> IO Word64
 getAccountBalanceNow pw Fix{..} = do
@@ -298,7 +298,7 @@ spec = do
             monadicIO $ do
                 pm <- pick arbitrary
                 let nm = makeNetworkMagic pm
-                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin))
+                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.V1 coin))
                                 <$> pick (genPayeeWithNM nm mempty (PayLovelace 100))
                 withUtxosFixture @IO pm [300, 400, 500, 600, 5000000] $ \_keystore _activeLayer aw f@Fix{..} -> do
                     let pw = Kernel.walletPassive aw
@@ -322,7 +322,7 @@ spec = do
             monadicIO $ do
                 pm <- pick arbitrary
                 let nm = makeNetworkMagic pm
-                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin))
+                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.V1 coin))
                                 <$> pick (genPayeeWithNM nm mempty (PayLovelace 100))
                 withUtxosFixture @IO pm [300, 400, 500, 600, 5000000] $ \_keystore _activeLayer aw Fix{..} -> do
                     let pw = Kernel.walletPassive aw
@@ -398,7 +398,7 @@ spec = do
                     let sourceWallet = V1.WalletId (sformat build rootAddress)
                     let accountIndex = Kernel.Conv.toAccountId hdAccountId
                     let destinations =
-                            fmap (\(addr, coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin)
+                            fmap (\(addr, coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.V1 coin)
                                 ) fixturePayees
                     let newPayment = V1.Payment {
                                     pmtSource          = V1.PaymentSource sourceWallet accountIndex

--- a/test/unit/Test/Spec/NewPayment.hs
+++ b/test/unit/Test/Spec/NewPayment.hs
@@ -170,7 +170,7 @@ withPayment pm initialBalance toPay action = do
         let sourceWallet = V1.WalletId (sformat build rootAddress)
         let accountIndex = Kernel.Conv.toAccountId hdAccountId
         let destinations =
-                fmap (\(addr, coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin)
+                fmap (\(addr, coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.V1 coin)
                      ) fixturePayees
         let newPayment = V1.Payment {
                          pmtSource           = V1.PaymentSource sourceWallet accountIndex


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#119</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `Core.Address` doesn't use `V1` wrapper anymore.
- [x] `Core.Address` golden test passes for old and new versions.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
