### PR TITLE
Fix address public key derivation

### DIFF
--- a/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
+++ b/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
@@ -1,26 +1,61 @@
 {-------------------------------------------------------------------------------
 
-  This module provides utils to perform account public key child derivation:
+  This module provides utils to perform derivation of address public key from
+  account public key:
 
     account (parent) extended public key -> address (child) extended public key
 
 -------------------------------------------------------------------------------}
 
-module Cardano.Wallet.Kernel.Ed25519Bip44 (
-    deriveLvl3PublicKey
+module Cardano.Wallet.Kernel.Ed25519Bip44
+    ( ChangeChain(..)
+
+    -- key derivation functions
+    , deriveAddressPublicKey
+
+    -- helpers
+    , isInternalChange
     ) where
 
 import           Universum
 
 import           Pos.Crypto (PublicKey (..))
 
-import           Cardano.Crypto.Wallet (DerivationScheme (..), deriveXPub)
+import           Cardano.Crypto.Wallet (DerivationScheme (DerivationScheme2),
+                     deriveXPub)
+import           Test.QuickCheck (Arbitrary (..), elements)
+
+-- | Change chain. External chain is used for addresses that are meant to be visible
+-- outside of the wallet (e.g. for receiving payments). Internal chain
+-- is used for addresses which are not meant to be visible outside of
+-- the wallet and is used for return transaction change.
+data ChangeChain
+    = InternalChain
+    | ExternalChain
+    deriving (Show, Eq)
+
+instance Arbitrary ChangeChain where
+    arbitrary = elements [InternalChain, ExternalChain]
+
+isInternalChange :: ChangeChain -> Bool
+isInternalChange InternalChain = True
+isInternalChange _             = False
+
+-- Constant 0 is used for external chain and constant 1 for
+-- internal chain (also known as change addresses).
+changeToIndex :: ChangeChain -> Word32
+changeToIndex ExternalChain = 0
+changeToIndex InternalChain = 1
 
 -- | Derives address public key from the given account public key,
 -- using derivation scheme 2 (please see 'cardano-crypto' package).
-deriveLvl3PublicKey
-    :: PublicKey
-    -> Word32
-    -> Maybe PublicKey
-deriveLvl3PublicKey (PublicKey xpub) addressIx =
-    PublicKey <$> deriveXPub DerivationScheme2 xpub addressIx
+deriveAddressPublicKey
+    :: PublicKey       -- Account Public Key
+    -> ChangeChain     -- Change chain
+    -> Word32          -- Address Key Index
+    -> Maybe PublicKey -- Address Public Key
+deriveAddressPublicKey (PublicKey accXPub) changeChain addressIx = do
+    -- lvl4 derivation in bip44 is derivation of change chain
+    changeXPub <- deriveXPub DerivationScheme2 accXPub (changeToIndex changeChain)
+    -- lvl5 derivation in bip44 is derivation of change address chain
+    PublicKey <$> deriveXPub DerivationScheme2 changeXPub addressIx

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -8,24 +8,27 @@ import           Universum
 
 import           Pos.Crypto (PublicKey)
 
-import           Cardano.Wallet.Kernel.Ed25519Bip44 (deriveLvl3PublicKey)
+import           Cardano.Wallet.Kernel.Ed25519Bip44 (ChangeChain,
+                     deriveAddressPublicKey)
 
 import           Test.Hspec (Spec, describe, it)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.QuickCheck (Property, property)
 
 -- | It proves that we cannot derive address public key
--- if address index is too big.
-prop_cannotDerivelvl3PublicKeyForBigIx
+-- if address index is too big. We should be able to derive
+-- Address public key only with non-hardened address index
+prop_cannotDeriveAddressPublicKeyForBigIx
     :: PublicKey
+    -> ChangeChain
     -> Word32
     -> Property
-prop_cannotDerivelvl3PublicKeyForBigIx accountPublicKey addressIx = property $
+prop_cannotDeriveAddressPublicKeyForBigIx accountPublicKey change addressIx = property $
     if addressIx >= maxIx
         then isNothing result
         else isJust result
   where
-    result = deriveLvl3PublicKey accountPublicKey addressIx
+    result = deriveAddressPublicKey accountPublicKey change addressIx
     -- This is maximum value for soft derivation (only soft derivation
     -- is allowed to derive public key from public key).
     maxIx = 0x8000000
@@ -33,4 +36,4 @@ prop_cannotDerivelvl3PublicKeyForBigIx accountPublicKey addressIx = property $
 spec :: Spec
 spec = describe "Ed25519Bip44" $ do
     it "Derivation fails if address index is too big" $
-        property prop_cannotDerivelvl3PublicKeyForBigIx
+        property prop_cannotDeriveAddressPublicKeyForBigIx


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#41</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed current method for deriving address public key from account public key
https://github.com/input-output-hk/cardano-wallet/pull/133/files#diff-ab6bdce941f09e40581d4a2debad9d7aR26
    - added intermediate change internal derivation
- [x] Simplified naming of address public key derivation

# Comments

<!-- Additional comments or screenshots to attach if any -->

This commit fixes work done by #31. Instead of deriving address
public key dirrectly with account public key, bip44 specifies
intermediate Change derivation. Simplified naming.
https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Change

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
