### PR TITLE
Derive extended public key from extended private key

### DIFF
--- a/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
+++ b/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
@@ -1,9 +1,9 @@
 {-------------------------------------------------------------------------------
 
-  This module provides utils to perform derivation of address public key from
-  account public key:
+  This module provides utils to perform child key derivation for bip44:
 
     account (parent) extended public key -> address (child) extended public key
+    extended private key -> extended private key
 
 -------------------------------------------------------------------------------}
 
@@ -12,6 +12,7 @@ module Cardano.Wallet.Kernel.Ed25519Bip44
 
     -- key derivation functions
     , deriveAddressPublicKey
+    , derivePublicKey
 
     -- helpers
     , isInternalChange
@@ -19,7 +20,7 @@ module Cardano.Wallet.Kernel.Ed25519Bip44
 
 import           Universum
 
-import           Pos.Crypto (PublicKey (..))
+import           Pos.Crypto (EncryptedSecretKey, PublicKey (..), encToPublic)
 
 import           Cardano.Crypto.Wallet (DerivationScheme (DerivationScheme2),
                      deriveXPub)
@@ -59,3 +60,8 @@ deriveAddressPublicKey (PublicKey accXPub) changeChain addressIx = do
     changeXPub <- deriveXPub DerivationScheme2 accXPub (changeToIndex changeChain)
     -- lvl5 derivation in bip44 is derivation of change address chain
     PublicKey <$> deriveXPub DerivationScheme2 changeXPub addressIx
+
+-- | Generate extend private key from extended private key
+-- (EncryptedSecretKey is a wrapper around private key)
+derivePublicKey :: EncryptedSecretKey -> PublicKey
+derivePublicKey = encToPublic


### PR DESCRIPTION
Adds method described in the title

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#41</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a method to derive extended public key from extended private key


# Comments

<!-- Additional comments or screenshots to attach if any -->
~I was not shure should we use `EncryptedSecretKey` or a plain `XPrv`. If we were using plain `XPrv` provided by `cardano-crypto` then we would still have to wrapp all the functions with `EncprytedSecretKey` provided by `cardano-sl` (`crypto` repo). I believe this is the way to go but here is a remark on my slight confusion.~
~EDIT: I have decided to use `SecretKey` instead as it seems more appropriate~

EDIT2: We have decided to use `EncryptedSecretKey` after all (see comments bellow)

Additionally as implemented functions just re-exports function from `cardano-sl` I was not sure how to actually test the function. When skimmed over internals how `XPrv -> XPub` is implemented low level (used internally by this method) how to test this function would be to test is part of public key binary representation a subset of private key binary representation. I would have to go into more details to closely understand format of these keys but this seems out of scope? Also - I am not implementing anything new in this case - just re-exporting (whith changed function name).

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
