### PR TITLE
Remove V1 wrapper: explicit import V1/unV1 from 'cardano-sl' package.

### DIFF
--- a/src/Cardano/Wallet/API/V1/Types.hs
+++ b/src/Cardano/Wallet/API/V1/Types.hs
@@ -19,10 +19,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.API.V1.Types (
-    V1 (..)
-  , unV1
   -- * Swagger & REST-related types
-  , PasswordUpdate (..)
+    PasswordUpdate (..)
   , AccountUpdate (..)
   , NewAccount (..)
   , Update
@@ -391,8 +389,6 @@ instance Semigroup WalletPassPhrase where
 instance Monoid WalletPassPhrase where
     mempty = WalletPassPhrase mempty
     mappend = (<>)
-
-deriving newtype instance Num a => Num (V1 a)
 
 type WalletName = Text
 

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Settings.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Settings.hs
@@ -7,9 +7,9 @@ import           Universum
 import qualified Data.Text as T
 import           Data.Time.Units (Millisecond)
 
+import           Pos.Node.API (V1 (..))
 import           Pos.Util.CompileInfo (CompileTimeInfo, ctiGitRevision)
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import           Cardano.Wallet.Kernel.NodeStateAdaptor (NodeStateAdaptor)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -13,6 +13,7 @@ import           GHC.TypeLits (symbolVal)
 
 import           Pos.Core (Address, Coin, SlotCount, SlotId, decodeTextAddress,
                      flattenSlotId, getBlockCount)
+import           Pos.Node.API (unV1)
 import           Pos.Util.Wlog (Severity (..))
 
 import           Cardano.Wallet.API.Indices
@@ -21,7 +22,6 @@ import qualified Cardano.Wallet.API.Request.Filter as F
 import           Cardano.Wallet.API.Request.Pagination
 import qualified Cardano.Wallet.API.Request.Sort as S
 import           Cardano.Wallet.API.Response
-import           Cardano.Wallet.API.V1.Types (unV1)
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#119</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `V1` and `unV1` are imported explicitly from `cardano-sl` package.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

Unfortunately, there're two modules in `cardano-wallet` where we must use `V1` and `unV1`:

1. `Cardano.Wallet.WalletLayer.Kernel.Settings`
2. `Cardano.Wallet.WalletLayer.Kernel.Transactions`

This is because we use two types from `cardano-sl`, and these types require `V1` wrapper. So now, in these two modules we import `V1` and `unV1` explicitly from `Pos.Node.API`, not from `Cardano.Wallet.API.V1.Types`.