### PR TITLE
Derive address private key from account private key

### DIFF
--- a/cardano-sl.yaml
+++ b/cardano-sl.yaml
@@ -30,10 +30,10 @@ packages:
   commit: d094be301195fcd8ab864d793f114970426a4478
 
 - git: https://github.com/input-output-hk/cardano-report-server.git
-  commit: 9b96874d0f234554a5779d98762cc0a6773a532a
+  commit: 93f2246c54436e7f98cc363b4e0f8f1cb5e78717
 
-- git: https://github.com/angerman/cardano-crypto
-  commit: 1e436fe8b69e7c8b399937db394d99229fcd775c
+- git: https://github.com/input-output-hk/cardano-crypto
+  commit: 59eb60b3a227c615736db9bb1609fd5c20109098
 
 - git: https://github.com/andrewthad/haskell-ip
   commit: 9bb453139aa82cc973125091800422a523e1eb8f

--- a/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
+++ b/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
@@ -2,8 +2,9 @@
 
   This module provides utils to perform child key derivation for bip44:
 
-    account (parent) extended public key -> address (child) extended public key
-    extended private key -> extended private key
+    extended private key -> extended public key
+    account extended public key -> address extended public key
+    account extended private key -> address extended private key
 
 -------------------------------------------------------------------------------}
 
@@ -22,8 +23,7 @@ module Cardano.Wallet.Kernel.Ed25519Bip44
 import           Universum
 
 import           Pos.Crypto (EncryptedSecretKey (..), PassPhrase,
-                     PublicKey (..), ShouldCheckPassphrase (..),
-                     checkPassMatches, encToPublic)
+                     PublicKey (..), checkPassMatches, encToPublic)
 
 import           Cardano.Crypto.Wallet (DerivationScheme (DerivationScheme2),
                      deriveXPrv, deriveXPub)
@@ -73,15 +73,14 @@ deriveAddressPublicKey (PublicKey accXPub) changeChain addressIx = do
 -- using derivation scheme 2 (please see 'cardano-crypto' package).
 -- TODO: EncryptedSecretKey will be renamed to EncryptedPrivateKey in #164
 deriveAddressPrivateKey
-    :: ShouldCheckPassphrase    -- Weather to call @checkPassMatches@
-    -> PassPhrase               -- Passphrase used to encrypt Account Private Key
+    :: PassPhrase               -- Passphrase used to encrypt Account Private Key
     -> EncryptedSecretKey       -- Account Private Key
     -> ChangeChain              -- Change chain
     -> Word32                   -- Address Key Index
     -> Maybe EncryptedSecretKey -- Address Private Key
-deriveAddressPrivateKey (ShouldCheckPassphrase checkPass) passPhrase accEncPrvKey@(EncryptedSecretKey accXPrv passHash) changeChain addressIx = do
+deriveAddressPrivateKey passPhrase accEncPrvKey@(EncryptedSecretKey accXPrv passHash) changeChain addressIx = do
     -- enforce valid PassPhrase check
-    when checkPass $ checkPassMatches passPhrase accEncPrvKey
+    checkPassMatches passPhrase accEncPrvKey
         -- lvl4 derivation in bip44 is derivation of change chain
     let changeXPrv = deriveXPrv DerivationScheme2 passPhrase accXPrv (changeToIndex changeChain)
         -- lvl5 derivation in bip44 is derivation of address chain

--- a/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
+++ b/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
@@ -79,9 +79,9 @@ deriveAddressPrivateKey
     -> ChangeChain              -- Change chain
     -> Word32                   -- Address Key Index
     -> Maybe EncryptedSecretKey -- Address Private Key
-deriveAddressPrivateKey (ShouldCheckPassphrase checkPass) passPhrase accEncSK@(EncryptedSecretKey accXPrv passHash) changeChain addressIx = do
+deriveAddressPrivateKey (ShouldCheckPassphrase checkPass) passPhrase accEncPrvKey@(EncryptedSecretKey accXPrv passHash) changeChain addressIx = do
     -- enforce valid PassPhrase check
-    when checkPass $ checkPassMatches passPhrase accEncSK
+    when checkPass $ checkPassMatches passPhrase accEncPrvKey
         -- lvl4 derivation in bip44 is derivation of change chain
     let changeXPrv = deriveXPrv DerivationScheme2 passPhrase accXPrv (changeToIndex changeChain)
         -- lvl5 derivation in bip44 is derivation of address chain

--- a/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
+++ b/src/Cardano/Wallet/Kernel/Ed25519Bip44.hs
@@ -12,6 +12,7 @@ module Cardano.Wallet.Kernel.Ed25519Bip44
 
     -- key derivation functions
     , deriveAddressPublicKey
+    , deriveAddressPrivateKey
     , derivePublicKey
 
     -- helpers
@@ -20,10 +21,12 @@ module Cardano.Wallet.Kernel.Ed25519Bip44
 
 import           Universum
 
-import           Pos.Crypto (EncryptedSecretKey, PublicKey (..), encToPublic)
+import           Pos.Crypto (EncryptedSecretKey (..), PassPhrase,
+                     PublicKey (..), ShouldCheckPassphrase (..),
+                     checkPassMatches, encToPublic)
 
 import           Cardano.Crypto.Wallet (DerivationScheme (DerivationScheme2),
-                     deriveXPub)
+                     deriveXPrv, deriveXPub)
 import           Test.QuickCheck (Arbitrary (..), elements)
 
 -- | Change chain. External chain is used for addresses that are meant to be visible
@@ -48,6 +51,11 @@ changeToIndex :: ChangeChain -> Word32
 changeToIndex ExternalChain = 0
 changeToIndex InternalChain = 1
 
+-- | Generate extend private key from extended private key
+-- (EncryptedSecretKey is a wrapper around private key)
+derivePublicKey :: EncryptedSecretKey -> PublicKey
+derivePublicKey = encToPublic
+
 -- | Derives address public key from the given account public key,
 -- using derivation scheme 2 (please see 'cardano-crypto' package).
 deriveAddressPublicKey
@@ -58,10 +66,24 @@ deriveAddressPublicKey
 deriveAddressPublicKey (PublicKey accXPub) changeChain addressIx = do
     -- lvl4 derivation in bip44 is derivation of change chain
     changeXPub <- deriveXPub DerivationScheme2 accXPub (changeToIndex changeChain)
-    -- lvl5 derivation in bip44 is derivation of change address chain
+    -- lvl5 derivation in bip44 is derivation of address chain
     PublicKey <$> deriveXPub DerivationScheme2 changeXPub addressIx
 
--- | Generate extend private key from extended private key
--- (EncryptedSecretKey is a wrapper around private key)
-derivePublicKey :: EncryptedSecretKey -> PublicKey
-derivePublicKey = encToPublic
+-- | Derives address private key from the given account private key,
+-- using derivation scheme 2 (please see 'cardano-crypto' package).
+-- TODO: EncryptedSecretKey will be renamed to EncryptedPrivateKey in #164
+deriveAddressPrivateKey
+    :: ShouldCheckPassphrase    -- Weather to call @checkPassMatches@
+    -> PassPhrase               -- Passphrase used to encrypt Account Private Key
+    -> EncryptedSecretKey       -- Account Private Key
+    -> ChangeChain              -- Change chain
+    -> Word32                   -- Address Key Index
+    -> Maybe EncryptedSecretKey -- Address Private Key
+deriveAddressPrivateKey (ShouldCheckPassphrase checkPass) passPhrase accEncSK@(EncryptedSecretKey accXPrv passHash) changeChain addressIx = do
+    -- enforce valid PassPhrase check
+    when checkPass $ checkPassMatches passPhrase accEncSK
+        -- lvl4 derivation in bip44 is derivation of change chain
+    let changeXPrv = deriveXPrv DerivationScheme2 passPhrase accXPrv (changeToIndex changeChain)
+        -- lvl5 derivation in bip44 is derivation of address chain
+        addressXPrv = deriveXPrv DerivationScheme2 passPhrase changeXPrv addressIx
+    pure $ EncryptedSecretKey addressXPrv passHash

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -6,14 +6,17 @@ module Test.Spec.Ed25519Bip44 (spec) where
 
 import           Universum
 
-import           Pos.Crypto (PublicKey)
+import           Pos.Crypto (EncryptedSecretKey, PassPhrase, PublicKey,
+                     ShouldCheckPassphrase (..), checkPassMatches)
 
 import           Cardano.Wallet.Kernel.Ed25519Bip44 (ChangeChain,
-                     deriveAddressPublicKey)
+                     deriveAddressPrivateKey, deriveAddressPublicKey,
+                     derivePublicKey)
 
 import           Test.Hspec (Spec, describe, it)
 import           Test.Pos.Core.Arbitrary ()
-import           Test.QuickCheck (Property, property)
+import           Test.QuickCheck (Property, expectFailure, property, (===),
+                     (==>))
 
 -- | It proves that we cannot derive address public key
 -- if address index is too big. We should be able to derive
@@ -25,15 +28,104 @@ prop_cannotDeriveAddressPublicKeyForBigIx
     -> Property
 prop_cannotDeriveAddressPublicKeyForBigIx accountPublicKey change addressIx = property $
     if addressIx >= maxIx
-        then isNothing result
-        else isJust result
+        then isNothing addrPubKey
+        else isJust addrPubKey
   where
-    result = deriveAddressPublicKey accountPublicKey change addressIx
+    addrPubKey = deriveAddressPublicKey accountPublicKey change addressIx
     -- This is maximum value for soft derivation (only soft derivation
     -- is allowed to derive public key from public key).
     maxIx = 0x8000000
 
+-- | Deriving address public key should be equal to deriving address
+-- private key and extracting public key from it (works only for non-hardened child keys).
+--
+-- To compute the public child key of a parent private key:
+--  * N(CKDpriv((kpar, cpar), i)) (works always).
+--  * CKDpub(N(kpar, cpar), i) (works only for non-hardened child keys).
+--
+-- Thus:
+--
+-- N(CKDpriv((kpar, cpar), i)) === CKDpub(N(kpar, cpar), i)
+--
+-- if (kpar, cpar) is a non-hardened key.
+--
+-- For details see https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key
+prop_deriveAddressPublicFromAccountPrivateKey
+    :: PassPhrase
+    -> EncryptedSecretKey
+    -> ChangeChain
+    -> Word32
+    -> Property
+prop_deriveAddressPublicFromAccountPrivateKey passPhrase accEncSK changeChain addressIx =
+    -- TODO (akegalj): check coverage with quickcheck @cover@
+    -- FIXME (akegalj): instead of doing this create generator for non-hardened keys.
+    -- This should in average discard 50% of examples and will thus be
+    -- 50% slower.
+    isNonHardened addressIx ==> (addrPrvKey1 === addrPrvKey2)
+  where
+    isNonHardened = (< 0x80000000)
+    -- N(CKDpriv((kpar, cpar), i))
+    addrPrvKey1 =
+        derivePublicKey <$> deriveAddressPrivateKey
+            (ShouldCheckPassphrase False)
+            passPhrase
+            accEncSK
+            changeChain
+            addressIx
+    -- CKDpub(N(kpar, cpar), i)
+    addrPrvKey2 =
+        deriveAddressPublicKey
+            (derivePublicKey accEncSK)
+            changeChain
+            addressIx
+
+-- | Deriving address private key should always succeed
+-- if password is not checked
+prop_deriveAddressPrivateKeyNoPassword
+    :: PassPhrase
+    -> EncryptedSecretKey
+    -> ChangeChain
+    -> Word32
+    -> Property
+prop_deriveAddressPrivateKeyNoPassword passphrase encSecKey changeChain =
+    property . isJust .
+        deriveAddressPrivateKey
+            (ShouldCheckPassphrase False)
+            passphrase
+            encSecKey
+            changeChain
+
+-- | Deriving address private key should always fail
+-- if password is checked and differs from account private key password
+prop_deriveAddressPrivateKeyWrongPassword
+    :: PassPhrase
+    -> EncryptedSecretKey
+    -> ChangeChain
+    -> Word32
+    -> Property
+prop_deriveAddressPrivateKeyWrongPassword passPhrase accEncSK changeChain addressIx =
+    -- There is a really small possibility we will generate
+    -- two equal passwords - so this precondition will rarely fail
+    -- TODO (akegalj): check coverage with quickcheck @cover@
+    (isNothing $ checkPassMatches passPhrase accEncSK) ==> property (isJust addrPrvKey)
+  where
+    addrPrvKey =
+        deriveAddressPrivateKey
+            (ShouldCheckPassphrase True)
+            passPhrase
+            accEncSK
+            changeChain
+            addressIx
+
 spec :: Spec
 spec = describe "Ed25519Bip44" $ do
-    it "Derivation fails if address index is too big" $
-        property prop_cannotDeriveAddressPublicKeyForBigIx
+    describe "Deriving address public key" $ do
+        it "fails if address index is too big" $
+            property prop_cannotDeriveAddressPublicKeyForBigIx
+        it "should be equal to deriving address private key and extracting public part from it: N(CKDpriv((kpar, cpar), i)) === CKDpub(N(kpar, cpar), i)" $
+            property prop_deriveAddressPublicFromAccountPrivateKey
+    describe "Deriving address private key" $ do
+        it "should always succeed if password is not checked" $
+            property prop_deriveAddressPrivateKeyNoPassword
+        it "should always fail if password is checked and differs" $
+            expectFailure prop_deriveAddressPrivateKeyWrongPassword

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -36,7 +36,7 @@ prop_cannotDeriveAddressPublicKeyForBigIx accountPublicKey change addressIx = pr
     addrPubKey = deriveAddressPublicKey accountPublicKey change addressIx
     -- This is maximum value for soft derivation (only soft derivation
     -- is allowed to derive public key from public key).
-    maxIx = 0x8000000
+    maxIx = 0x80000000
 
 -- | Deriving address public key should be equal to deriving address
 -- private key and extracting public key from it (works only for non-hardened child keys).

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -80,13 +80,13 @@ prop_deriveAddressPublicFromAccountPrivateKey (InfiniteList seed _) passPhrase@(
 
 -- | Deriving address private key should always fail
 -- if account index is hardened
-prop_deriveAddressPrivateKeyNoHardened
+prop_deriveAddressPrivateKeyHardened
     :: InfiniteList Word8
     -> PassPhrase
     -> ChangeChain
     -> Word32
     -> Property
-prop_deriveAddressPrivateKeyNoHardened (InfiniteList seed _) passPhrase@(PassPhrase passBytes) changeChain addressIx =
+prop_deriveAddressPrivateKeyHardened (InfiniteList seed _) passPhrase@(PassPhrase passBytes) changeChain addressIx =
     isHardened addressIx ==> property (isJust addrPrvKey)
   where
     accEncPrvKey = mkEncSecretWithSaltUnsafe emptySalt passPhrase $ generate (BS.pack $ take 32 seed) passBytes
@@ -129,4 +129,4 @@ spec = describe "Ed25519Bip44" $ do
         it "fails if password differs" $
             expectFailure prop_deriveAddressPrivateKeyWrongPassword
         it "fails if address index is hardened" $
-            expectFailure prop_deriveAddressPrivateKeyNoHardened
+            expectFailure prop_deriveAddressPrivateKeyHardened

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -19,7 +19,7 @@ import qualified Data.ByteString as BS
 import           Test.Hspec (Spec, describe, it)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.QuickCheck (InfiniteList (..), Property, expectFailure,
-                     property, (===), (==>))
+                     property, (.&&.), (===), (==>))
 
 -- | It proves that we cannot derive address public key
 -- if address index is too big. We should be able to derive
@@ -61,7 +61,7 @@ prop_deriveAddressPublicFromAccountPrivateKey (InfiniteList seed _) passPhrase@(
     -- FIXME (akegalj): instead of doing this create generator for non-hardened keys.
     -- This should in average discard 50% of examples and will thus be
     -- 50% slower.
-    not (isHardened addressIx) ==> (addrPubKey1 === addrPubKey2)
+    not (isHardened addressIx) ==> (isJust addrPubKey1 .&&. addrPubKey1 === addrPubKey2)
   where
     accEncPrvKey = mkEncSecretWithSaltUnsafe emptySalt passPhrase $ generate (BS.pack $ take 32 seed) passBytes
     -- N(CKDpriv((kpar, cpar), i))


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#41</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a method to derive address private key from account private key
- [x] I have added property tests to check the above method

# Comments

<!-- Additional comments or screenshots to attach if any -->

~For some reason property test https://github.com/input-output-hk/cardano-wallet/compare/akegalj/41/derive-addrPrvKey-from-accPrvKey?expand=1#diff-e9a62968e1cca775db414be6d317ecadR125 fails and I have to debug where the issue is. In theory it should work~
Edit: fixed with https://github.com/input-output-hk/cardano-crypto/pull/52
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
