### PR TITLE
Remove V1 wrapper: reduce usage of WalAddress in Kernel-layer.

### DIFF
--- a/src/Cardano/Wallet/API/Indices.hs
+++ b/src/Cardano/Wallet/API/Indices.hs
@@ -65,6 +65,10 @@ instance ToIndex WalletAddress WalAddress where
     toIndex _ = fmap WalAddress . either (const Nothing) Just . Core.decodeTextAddress
     accessIx WalletAddress{..} = addrId
 
+instance ToIndex WalletAddress Core.Address where
+    toIndex _ = either (const Nothing) Just . Core.decodeTextAddress
+    accessIx WalletAddress{..} = let (WalAddress addr) = addrId in addr
+
 --
 -- Primary and secondary indices for V1 types
 --
@@ -138,7 +142,8 @@ type family IndexToQueryParam resource ix where
     IndexToQueryParam Wallet  WalletId                = "id"
     IndexToQueryParam Wallet  WalletTimestamp         = "created_at"
 
-    IndexToQueryParam WalletAddress (WalAddress)      = "address"
+    IndexToQueryParam WalletAddress Core.Address      = "address"
+    IndexToQueryParam WalletAddress WalAddress        = "address"
 
     IndexToQueryParam Transaction WalletTxId         = "id"
     IndexToQueryParam Transaction WalletTimestamp    = "created_at"
@@ -167,6 +172,7 @@ instance KnownQueryParam Account AccountIndex
 instance KnownQueryParam Wallet Core.Coin
 instance KnownQueryParam Wallet WalletId
 instance KnownQueryParam Wallet WalletTimestamp
+instance KnownQueryParam WalletAddress Core.Address
 instance KnownQueryParam WalletAddress WalAddress
 instance KnownQueryParam Transaction WalletTxId
 instance KnownQueryParam Transaction WalletTimestamp

--- a/src/Cardano/Wallet/API/V1/Types.hs
+++ b/src/Cardano/Wallet/API/V1/Types.hs
@@ -334,6 +334,14 @@ instance FromHttpApiData WalAddress where
 instance ToHttpApiData WalAddress where
     toQueryParam (WalAddress a) = sformat build a
 
+-- | We need 'FromHttpApiData' and 'ToHttpApiData' instances for 'Core.Address',
+-- it is required for 'filterHdAddress' in 'Cardano.Wallet.WalletLayer.Kernel.Accounts'.
+instance FromHttpApiData Core.Address where
+    parseQueryParam = Core.decodeTextAddress
+
+instance ToHttpApiData Core.Address where
+    toQueryParam = sformat build
+
 deriving instance Hashable WalAddress
 deriving instance NFData WalAddress
 

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -116,7 +116,6 @@ import           Pos.Core.Chrono (NewestFirst (..))
 import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto as Core
 
-import           Cardano.Wallet.API.V1.Types (WalAddress (..))
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Spec
@@ -590,7 +589,7 @@ instance HasPrimKey (Indexed HdAddress) where
 
 type SecondaryHdRootIxs           = '[]
 type SecondaryHdAccountIxs        = '[HdRootId]
-type SecondaryIndexedHdAddressIxs = '[AutoIncrementKey, HdRootId, HdAccountId, WalAddress]
+type SecondaryIndexedHdAddressIxs = '[AutoIncrementKey, HdRootId, HdAccountId, Core.Address]
 
 type instance IndicesOf HdRoot              = SecondaryHdRootIxs
 type instance IndicesOf HdAccount           = SecondaryHdAccountIxs
@@ -611,7 +610,7 @@ instance IxSet.Indexable (HdAddressId ': SecondaryIndexedHdAddressIxs)
                 (ixFun ((:[]) . view ixedIndex))
                 (ixFun ((:[]) . view (ixedIndexed . hdAddressRootId)))
                 (ixFun ((:[]) . view (ixedIndexed . hdAddressAccountId)))
-                (ixFun ((:[]) . WalAddress . view (ixedIndexed . hdAddressAddress . fromDb)))
+                (ixFun ((:[]) . view (ixedIndexed . hdAddressAddress . fromDb)))
 
 {-------------------------------------------------------------------------------
   Top-level HD wallet structure
@@ -690,7 +689,7 @@ zoomHdCardanoAddress embedErr addr =
     findAddress :: Query' e HdWallets HdAddress
     findAddress = do
         addresses <- view hdWalletsAddresses
-        maybe err return $ (fmap _ixedIndexed $ getOne $ getEQ (WalAddress addr) addresses)
+        maybe err return $ (fmap _ixedIndexed $ getOne $ getEQ addr addresses)
 
     err :: Query' e HdWallets x
     err = missing $ embedErr (UnknownHdCardanoAddress addr)

--- a/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
@@ -18,7 +18,6 @@ import qualified Data.Set as Set
 import qualified Pos.Chain.Txp as Core
 import qualified Pos.Core as Core
 
-import           Cardano.Wallet.API.V1.Types (WalAddress (..))
 import           Cardano.Wallet.Kernel.DB.BlockMeta (blockMetaSlotId,
                      localBlockMeta)
 import           Cardano.Wallet.Kernel.DB.HdWallet
@@ -72,7 +71,7 @@ cpChange ours cp =
       (Pending.change ours' $ cp ^. cpForeign)
   where
     ours' :: Core.Address -> Bool
-    ours' addr = IxSet.size (IxSet.getEQ (WalAddress addr) ours) == 1
+    ours' addr = IxSet.size (IxSet.getEQ addr ours) == 1
 
 -- | Total balance (available balance plus change)
 cpTotalBalance :: IsCheckpoint c => IxSet (Indexed HdAddress) -> c -> Core.Coin

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
@@ -167,7 +167,7 @@ getAccountAddresses wId accIx rp fo snapshot = runExcept $ do
 -------------------------------------------------------------------------------}
 
 filterHdAddress :: FilterOperations '[V1.WalAddress] WalletAddress
-                -> FilterOperations '[V1.WalAddress] (Indexed HD.HdAddress)
+                -> FilterOperations '[Core.Address] (Indexed HD.HdAddress)
 filterHdAddress NoFilters               = NoFilters
 filterHdAddress (FilterNop NoFilters)   = FilterNop NoFilters
 filterHdAddress (FilterOp op NoFilters) = FilterOp (coerce op) NoFilters


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#119</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Usage of `WalAddress` in Kernel-layer is reduced.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

Since `WalAddress` is defined at API-level, it shouldn't be used in Kernel-layer. Unfortunately, there is still one module `Cardano.Wallet.Kernel.Decrypt` that using `WalAddress`.