### PR TITLE
Add support for unsafe requests in the integration DSL

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -5,7 +5,7 @@
 # This file contains a template configuration file, which is typically
 # placed as .hlint.yaml in the root of your project
 
-- arguments: [-XTypeApplications, --cpp-define=CONFIG=dev]
+- arguments: [-XTypeApplications, -XQuasiQuotes, --cpp-define=CONFIG=dev]
 
 - ignore: {name: Redundant do}
 - ignore: {name: Redundant bracket}

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -237,6 +237,7 @@ language_extensions:
   - OverloadedLabels
   - OverloadedStrings
   - PolyKinds
+  - QuasiQuotes
   - RecordWildCards
   - ScopedTypeVariables
   - StandaloneDeriving

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -557,6 +557,7 @@ test-suite integration
       NoMonomorphismRestriction
       OverloadedStrings
       OverloadedLabels
+      QuasiQuotes
       ScopedTypeVariables
       TupleSections
       TypeApplications
@@ -572,7 +573,10 @@ test-suite integration
   build-depends:
       base
     , QuickCheck
+    , aeson
+    , aeson-qq
     , async
+    , bytestring
     , cardano-sl
     , cardano-sl-chain
     , cardano-sl-client
@@ -588,7 +592,12 @@ test-suite integration
     , hspec
     , hspec-core
     , hspec-expectations-lifted
+    , http-api-data
+    , http-client
+    , http-types
     , optparse-applicative
+    , servant-client-core
+    , template-haskell
     , text
     , universum
 

--- a/src/Cardano/Wallet/Client.hs
+++ b/src/Cardano/Wallet/Client.hs
@@ -373,6 +373,8 @@ data ClientError
     = ClientWalletError WalletError
     -- ^ The 'WalletError' type represents known failures that the API
     -- might return.
+    | ClientJSONError JSONValidationError
+    -- ^ Error returned when submitting an invalid JSON object
     | ClientHttpError ServantError
     -- ^ We directly expose the 'ServantError' type as part of this
     | UnknownClientError SomeException
@@ -384,6 +386,7 @@ data ClientError
 -- | General (and naive) equality instance.
 instance Eq ClientError where
     ClientWalletError  e1 == ClientWalletError  e2 = e1 == e2
+    ClientJSONError    e1 == ClientJSONError    e2 = e1 == e2
     ClientHttpError    e1 == ClientHttpError    e2 = e1 == e2
     UnknownClientError _  == UnknownClientError _  = True
     _ == _ = False
@@ -391,5 +394,6 @@ instance Eq ClientError where
 -- | General exception instance.
 instance Exception ClientError where
     toException (ClientWalletError  e) = toException e
+    toException (ClientJSONError    e) = toException e
     toException (ClientHttpError    e) = toException e
     toException (UnknownClientError e) = toException e

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -30,15 +30,17 @@ main = do
         , ("relay", NodeRelay)
         , ("edge", NodeEdge)
         ]
-    let wClient = mkHttpClient (toBaseUrl $ env ! "WALLET_ADDRESS") manager
-    let dClient = mkHttpDocClient (toBaseUrl $ env ! "WALLET_DOC_ADDRESS") manager
+    let wAddr   = toBaseUrl $ env ! "WALLET_ADDRESS"
+    let dAddr   = toBaseUrl $ env ! "WALLET_DOC_ADDRESS"
+    let wClient = mkHttpClient wAddr manager
+    let dClient = mkHttpDocClient dAddr manager
     waitForNode wClient (MaxWaitingTime 90)
 
     -- Run tests
     hspec $ do
         describe "API Documentation" $ Documentation.spec dClient
 
-        beforeAll (newMVar $ Context keys wClient) $ do
+        beforeAll (newMVar $ Context keys wClient (wAddr, manager)) $ do
             describe "Accounts" Accounts.spec
             describe "Addresses" Addresses.spec
             describe "Transactions" Transactions.spec

--- a/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -4,12 +4,24 @@ module Test.Integration.Scenario.Wallets
 
 import           Universum
 
+import           Cardano.Wallet.Client.Http (ClientError, Wallet)
 import qualified Cardano.Wallet.Client.Http as Client
 import           Test.Integration.Framework.DSL
 
-
 spec :: Scenarios Context
 spec = do
+    scenario "demo unsafeRequest" $ do
+        fixture <- setup $ defaultSetup
+
+        let endpoint = "api" </> "v1" </> "wallets" </> fixture ^. wallet . walletId
+        response <- unsafeRequest ("PUT", endpoint) $ Just $ [json|{
+            "invalidField": #{fixture ^. wallet}
+        }|]
+
+        verify (response :: Either ClientError Wallet)
+            [ expectJSONError "key assuranceLevel was not present"
+            ]
+
     scenario "wallet is available after it's been created" $ do
         fixture <- setup $ defaultSetup
             & walletName .~ "漢patate字"


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#173</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added an `unsafeRequest` combinator that can be used to submit raw requests to the API, specifying methods, endpoint and body by hand (can't yet customize headers, but that's an improvement we could imagine)

- [x] I have added an extra `(</>)` combinator to easily create paths containing variables from ids

- [x] I have added an extra `expectJSONError` combinator to expect a response to return a JSON validation error containing a given message.

- [x] I have added a dummy integration test example that illustrate all the above.

# Comments

<!-- Additional comments or screenshots to attach if any -->

We may want to remove the example in the future as it serves no real purpose :) 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
