### PR TITLE
#88 Add applying blocks via diffusion and comment out old mechanism

### DIFF
--- a/src/Cardano/Wallet/Action.hs
+++ b/src/Cardano/Wallet/Action.hs
@@ -30,8 +30,9 @@ import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 import           Cardano.Wallet.Kernel.NodeStateAdaptor (newNodeStateAdaptor)
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as NodeStateAdaptor
 import           Cardano.Wallet.Server.CLI (WalletBackendParams (..),
-                     getFullMigrationFlag, getWalletDbOptions, walletDbPath,
-                     walletNodeAddress, walletRebuildDb)
+                     getApplyBlockPullMechanismFlag, getFullMigrationFlag,
+                     getWalletDbOptions, walletDbPath, walletNodeAddress,
+                     walletRebuildDb)
 import           Cardano.Wallet.Server.Middlewares
                      (faultInjectionHandleIgnoreAPI, throttleMiddleware,
                      unsupportedMimeTypeMiddleware, withDefaultHeader)
@@ -82,8 +83,9 @@ actionWithWallet
             , Kernel.dbPathMetadata  = dbPath <> "-sqlite.sqlite3"
             , Kernel.dbRebuild       = rebuildDB
             })
+        let usePullMechanism = getApplyBlockPullMechanismFlag params
         let pm = configProtocolMagic genesisConfig
-        WalletLayer.Kernel.bracketPassiveWallet pm dbMode logMessage' keystore nodeState (npFInjects nodeParams) $ \walletLayer passiveWallet -> do
+        WalletLayer.Kernel.bracketPassiveWallet pm dbMode usePullMechanism logMessage' keystore nodeState (npFInjects nodeParams) $ \walletLayer passiveWallet -> do
             migrateLegacyDataLayer passiveWallet dbPath (getFullMigrationFlag params)
 
             let plugs = plugins (walletLayer, passiveWallet) nodeClient dbMode
@@ -131,4 +133,3 @@ actionWithWallet
       where
         loggerName :: LoggerName
         loggerName = lpDefaultName . bpLoggingParams . npBaseParams $ nodeParams
-

--- a/src/Cardano/Wallet/Kernel.hs
+++ b/src/Cardano/Wallet/Kernel.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Kernel (
     , walletLogMessage
     , walletPassive
     , walletMeta
+    , walletProcessedBlocks
       -- * Active wallet
     , ActiveWallet -- opaque
     , bracketActiveWallet
@@ -181,6 +182,7 @@ initPassiveWallet pm logMessage keystore handles node fInjects = do
                 , _walletSubmission      = submission
                 , _walletRestorationTask = restore
                 , _walletFInjects        = fInjects
+                , _walletProcessedBlocks = []
                 }
 
         -- | Since the submission layer state is not persisted, we need to initialise
@@ -207,6 +209,7 @@ bracketActiveWallet walletPassive
       tickSubmissionLayer
         (walletPassive ^. walletLogMessage)
         (tickFunction (walletPassive ^. walletSubmission))
+
     bracket
       (return ActiveWallet{..})
       (\_ -> liftIO $ do

--- a/src/Cardano/Wallet/Kernel/DB/BlockContext.hs
+++ b/src/Cardano/Wallet/Kernel/DB/BlockContext.hs
@@ -46,7 +46,7 @@ data BlockContext = BlockContext {
       -- we do some work to figure out what the previous /main/ block was.
       -- See 'mostRecentMainBlock'.
     , _bcPrevMain :: !(Strict.Maybe (InDb Core.HeaderHash))
-    } deriving Eq
+    } deriving (Eq, Show)
 
 makeLenses ''BlockContext
 deriveSafeCopy 1 'base ''BlockContext

--- a/src/Cardano/Wallet/Kernel/DB/Resolved.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Resolved.hs
@@ -61,7 +61,7 @@ data ResolvedTx = ResolvedTx {
 
      -- | Transaction Meta
     , _rtxMeta    :: InDb (TxId, Timestamp)
-    }
+    } deriving Show
 
 -- | (Unsigned block) containing resolved transactions
 --
@@ -77,7 +77,7 @@ data ResolvedBlock = ResolvedBlock {
 
       -- | Creation time of this block
     , _rbMeta    :: !Timestamp
-    }
+    } deriving Show
 
 makeLenses ''ResolvedTx
 makeLenses ''ResolvedBlock

--- a/src/Cardano/Wallet/Kernel/Diffusion.hs
+++ b/src/Cardano/Wallet/Kernel/Diffusion.hs
@@ -1,17 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 module Cardano.Wallet.Kernel.Diffusion (
     WalletDiffusion(..)
   , fromDiffusion
+  , tickDiffusionLayer
   ) where
 
 import           Universum
 
-import           Pos.Chain.Txp (TxAux)
+import           Control.Concurrent (threadDelay)
+import qualified Data.Map.Strict as Map
+import           Formatting (sformat, (%))
+import qualified Formatting as F
+
+import           Pos.Chain.Block (Block, BlockHeader, HeaderHash, prevBlockL)
+import           Pos.Chain.Txp (TxAux, Utxo)
 import           Pos.Core ()
+import           Pos.Core.Chrono (OldestFirst (..))
+import           Pos.DB.Block (MonadBlockVerify)
 import           Pos.Infra.Communication.Types.Protocol (NodeId)
 import           Pos.Infra.Diffusion.Subscription.Status (SubscriptionStatus,
                      ssMap)
 import           Pos.Infra.Diffusion.Types
+import           Pos.Util.Wlog (Severity (..))
+
 
 -- | Wallet diffusion layer
 --
@@ -33,13 +45,90 @@ data WalletDiffusion = WalletDiffusion {
 
       -- | Get subscription status (needed for the node settings endpoint)
     , walletGetSubscriptionStatus :: IO (Map NodeId SubscriptionStatus)
+
+      -- | Request tip-of-chain from the network
+    , walletRequestTip            :: IO (Map NodeId (IO BlockHeader))
+
+      -- | Get blocks from checkpoint up to the header (not-included) from the node
+    , walletGetBlocks
+        :: NodeId
+        -> HeaderHash
+        -> [HeaderHash]
+        -> IO (OldestFirst [] Block)
+
     }
 
 -- | Extract necessary functionality from the full diffusion layer
-fromDiffusion :: (forall a. m a -> IO a)
+fromDiffusion :: forall m ctx .
+                 (MonadBlockVerify ctx m)
+              => (forall a. m a -> IO a)
               -> Diffusion m
               -> WalletDiffusion
 fromDiffusion nat d = WalletDiffusion {
       walletSendTx                = nat . sendTx d
     , walletGetSubscriptionStatus = readTVarIO $ ssMap (subscriptionStates d)
+    , walletRequestTip            = do
+           fromDiff <- nat $ requestTip d
+           pure $ Map.map nat fromDiff
+    , walletGetBlocks             = \nodeId from toNotIncluding -> do
+            case toNotIncluding of
+                [lastConsumedHeader] ->
+                    nat $ getPrevBlock nodeId from (Just lastConsumedHeader) []
+                _ ->
+                    nat $ getPrevBlock nodeId from Nothing []
     }
+    where
+        getPrevBlock
+            :: NodeId
+            -> HeaderHash
+            -> Maybe HeaderHash
+            -> [Block]
+            -> m (OldestFirst [] Block)
+        getPrevBlock nodeId from toMaybe blocksInThisBatch = do
+            blocks <- getOldestFirst <$> getBlocks d nodeId from [from]
+            case blocks of
+                [block@(Right _)] -> do
+                    -- here we are dealing with MainBlock
+                    let prevBlockHeader = block ^. prevBlockL
+                    case toMaybe of
+                        Just upToHeader ->
+                            if (prevBlockHeader /= upToHeader) then
+                                -- still need to download backwards
+                                getPrevBlock nodeId prevBlockHeader toMaybe (block : blocksInThisBatch)
+                            else
+                                -- we just downloaded the last missing block
+                                pure $ OldestFirst $ block : blocksInThisBatch
+                        Nothing -> do
+                            -- just one block downloaded
+                            pure $ OldestFirst (block : blocksInThisBatch)
+                _ -> do
+                    pure $ OldestFirst blocksInThisBatch
+
+
+tickDiffusionLayer
+    :: forall m. (MonadCatch m, MonadIO m)
+    => (Severity -> Text -> m ())
+       -- ^ A logging function
+    -> ( (Severity -> Text -> m ()) -> (([HeaderHash],[HeaderHash]),Utxo) -> m (([HeaderHash],[HeaderHash]), Utxo) )
+       -- ^ A function to call at each 'tick' of the worker.
+       -- This callback will be responsible for doing any pre
+       -- and post processing of the state.
+    -> (([HeaderHash],[HeaderHash]),Utxo)
+    -> m ()
+tickDiffusionLayer logFunction tick initialState =
+    go initialState
+    `catch`
+    (\(e :: SomeException) ->
+            let msg = "Terminating tickDiffusionLayer due to " % F.shown
+            in logFunction Error (sformat msg e)
+    )
+    where
+      go :: (([HeaderHash],[HeaderHash]), Utxo) -> m ()
+      go previousState  = do
+          logFunction Debug "ticking the slot in the diffusion layer..."
+          currentState <- tick logFunction previousState
+          liftIO $ threadDelay tickDiffusionRate
+          go currentState
+
+tickDiffusionRate :: Int
+tickDiffusionRate = 1000000

--- a/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/src/Cardano/Wallet/Kernel/Internal.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Kernel.Internal (
   , walletSubmission
   , walletRestorationTask
   , walletFInjects
+  , walletProcessedBlocks
     -- * Active wallet
   , ActiveWallet(..)
     -- * Restoration data
@@ -51,6 +52,7 @@ import           Control.Lens.TH
 import           Data.Acid (AcidState)
 import qualified Data.Map.Strict as Map
 
+import           Pos.Chain.Block (HeaderHash)
 import           Pos.Core (BlockCount, FlatSlotId)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.InjectFail (FInjects)
@@ -130,6 +132,9 @@ data PassiveWallet = PassiveWallet {
 
       -- | Failure injection handle:  a stateful set of active fault injections.
     , _walletFInjects        :: FInjects IO
+
+      -- | Block headers of all blocks that the wallet processed
+    , _walletProcessedBlocks :: [HeaderHash]
     }
 
 {-------------------------------------------------------------------------------

--- a/src/Cardano/Wallet/Kernel/Submission/Worker.hs
+++ b/src/Cardano/Wallet/Kernel/Submission/Worker.hs
@@ -11,14 +11,15 @@ import qualified Formatting as F
 import           Pos.Util.Wlog (Severity (..))
 
 
-tickSubmissionLayer :: forall m. (MonadCatch m, MonadIO m)
-                    => (Severity -> Text -> m ())
-                    -- ^ A logging function
-                    -> IO ()
-                    -- ^ A function to call at each 'tick' of the worker.
-                    -- This callback will be responsible for doing any pre
-                    -- and post processing of the state.
-                    -> m ()
+tickSubmissionLayer
+    :: forall m. (MonadCatch m, MonadIO m)
+    => (Severity -> Text -> m ())
+       -- ^ A logging function
+    -> IO ()
+       -- ^ A function to call at each 'tick' of the worker.
+       -- This callback will be responsible for doing any pre
+       -- and post processing of the state.
+    -> m ()
 tickSubmissionLayer logFunction tick =
     go `catch` (\(e :: SomeException) ->
                    let msg = "Terminating tickSubmissionLayer due to " % F.shown

--- a/src/Cardano/Wallet/Server/Plugins.hs
+++ b/src/Cardano/Wallet/Server/Plugins.hs
@@ -60,6 +60,8 @@ import           Cardano.Wallet.WalletLayer (ActiveWalletLayer,
                      PassiveWalletLayer)
 import qualified Cardano.Wallet.WalletLayer.Kernel as WalletLayer.Kernel
 
+import           Data.Reflection (Given (..))
+import           Pos.Chain.Ssc (SscConfiguration, sscConfiguration)
 import           Pos.Infra.Diffusion.Types (Diffusion (..))
 import           Pos.Infra.Shutdown (HasShutdownContext (shutdownContext),
                      ShutdownContext)
@@ -69,6 +71,10 @@ import           Pos.Util.Wlog (logError, logInfo, modifyLoggerName,
                      usingLoggerName)
 import           Pos.Web (serveDocImpl, serveImpl)
 import qualified Pos.Web.Server
+
+
+instance Given SscConfiguration where
+    given = sscConfiguration
 
 -- A @Plugin@ running in the monad @m@.
 type Plugin m = Diffusion m -> m ()
@@ -104,7 +110,7 @@ apiServer
             <> show err
         Right _ -> do
             logInfo "The node responded successfully."
-    WalletLayer.Kernel.bracketActiveWallet passiveLayer passiveWallet diffusion' $ \active _ -> do
+    WalletLayer.Kernel.bracketActiveWallet passiveLayer passiveWallet diffusion' walletApplyBlockPullMechanism $ \active _ -> do
         ctx <- view shutdownContext
         serveImpl
             (getApplication active)

--- a/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -9,34 +9,51 @@ module Cardano.Wallet.WalletLayer.Kernel
 
 import           Universum hiding (for_)
 
+import           Control.Concurrent.Async (async, cancel)
 import qualified Control.Concurrent.STM as STM
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
-import qualified Data.List.NonEmpty as NE
-
 import           Data.Foldable (for_)
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Strict.Maybe as StrictMaybe
 import           Formatting ((%))
 import qualified Formatting as F
 
-import           Pos.Chain.Block (Blund, blockHeader, headerHash, prevBlockL)
+import           Pos.Chain.Block (Blund, HeaderHash, blockHeader,
+                     getBlockHeader, headerHash, mainBlockSlot,
+                     mainBlockTxPayload, prevBlockL)
 import           Pos.Chain.Genesis (Config (..))
+import           Pos.Chain.Txp (Tx (..), TxIn (..), Utxo, txpTxs, utxoToLookup)
+import           Pos.Core (getCurrentTimestamp)
 import           Pos.Core.Chrono (OldestFirst (..))
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.InjectFail (FInjects)
-import           Pos.Util.Wlog (Severity (Debug, Warning))
+import           Pos.Util.Wlog (Severity (..))
+import           UTxO.Context (CardanoContext (..), initCardanoContext)
+
 
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.Actions as Actions
 import qualified Cardano.Wallet.Kernel.BListener as Kernel
 import           Cardano.Wallet.Kernel.DB.AcidState (dbHdWallets)
+import           Cardano.Wallet.Kernel.DB.BlockContext (BlockContext (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet (hdAccountRestorationState,
                      hdRootId, hdWalletsRoots)
+import           Cardano.Wallet.Kernel.DB.InDb
 import qualified Cardano.Wallet.Kernel.DB.Read as Kernel
+import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock (..),
+                     ResolvedTx (..))
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
-import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
+import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..),
+                     tickDiffusionLayer)
 import           Cardano.Wallet.Kernel.Keystore (Keystore)
 import           Cardano.Wallet.Kernel.NodeStateAdaptor
 import qualified Cardano.Wallet.Kernel.Read as Kernel
 import qualified Cardano.Wallet.Kernel.Restore as Kernel
+import           Cardano.Wallet.Kernel.Util.Core (txOuts, utxoRemoveInputs,
+                     utxoUnions)
 import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..),
                      PassiveWalletLayer (..))
 import qualified Cardano.Wallet.WalletLayer.Kernel.Accounts as Accounts
@@ -46,18 +63,20 @@ import qualified Cardano.Wallet.WalletLayer.Kernel.Internal as Internal
 import qualified Cardano.Wallet.WalletLayer.Kernel.Transactions as Transactions
 import qualified Cardano.Wallet.WalletLayer.Kernel.Wallets as Wallets
 
+
 -- | Initialize the passive wallet.
 -- The passive wallet cannot send new transactions.
 bracketPassiveWallet
     :: forall m n a. (MonadIO n, MonadUnliftIO m, MonadMask m)
     => ProtocolMagic
     -> Kernel.DatabaseMode
+    -> Bool
     -> (Severity -> Text -> IO ())
     -> Keystore
     -> NodeStateAdaptor IO
     -> FInjects IO
     -> (PassiveWalletLayer n -> Kernel.PassiveWallet -> m a) -> m a
-bracketPassiveWallet pm mode logFunction keystore node fInjects f = do
+bracketPassiveWallet pm mode usePullMechanism logFunction keystore node fInjects f = do
     Kernel.bracketPassiveWallet pm mode logFunction keystore node fInjects $ \w -> do
 
       -- For each wallet in a restoration state, re-start the background
@@ -80,11 +99,15 @@ bracketPassiveWallet pm mode logFunction keystore node fInjects f = do
 
       -- Start the wallet worker
       let wai = Actions.WalletActionInterp
-                 { Actions.applyBlocks = \blunds -> do
-                    ls <- mapM (Wallets.blundToResolvedBlock node)
-                        (toList (getOldestFirst blunds))
-                    let mp = catMaybes ls
-                    mapM_ (Kernel.applyBlock w) mp
+                { Actions.applyBlocks =
+                  if usePullMechanism then
+                      \_ -> return ()
+                  else
+                      \blunds -> do
+                          ls <- mapM (Wallets.blundToResolvedBlock node)
+                              (toList (getOldestFirst blunds))
+                          let mp = catMaybes ls
+                          mapM_ (Kernel.applyBlock w) mp
 
                  , Actions.switchToFork = \_ (OldestFirst blunds) -> do
                      -- Get the hash of the last main block before this fork.
@@ -155,13 +178,40 @@ bracketActiveWallet
     => PassiveWalletLayer n
     -> Kernel.PassiveWallet
     -> WalletDiffusion
+    -> Bool
     -> (ActiveWalletLayer n -> Kernel.ActiveWallet -> m a) -> m a
-bracketActiveWallet walletPassiveLayer passiveWallet walletDiffusion runActiveLayer =
-    Kernel.bracketActiveWallet passiveWallet walletDiffusion $ \w -> do
-        bracket
-          (return (activeWalletLayer w))
-          (\_ -> return ())
-          (flip runActiveLayer w)
+bracketActiveWallet walletPassiveLayer passiveWallet walletDiffusion walletApplyBlockPullMechanism runActiveLayer =
+    Kernel.bracketActiveWallet passiveWallet walletDiffusion $ \w ->
+
+        if walletApplyBlockPullMechanism then do
+
+            liftIO $ logging Debug "pull mechanism (diffusion layer based) for block syncing is active"
+
+            genesisConfig <- liftIO $ getCoreConfig $ passiveWallet ^. Kernel.walletNode
+            let initialUtxo = ccUtxo $ initCardanoContext genesisConfig
+            let headersConsumed = passiveWallet ^. Kernel.walletProcessedBlocks
+
+            applyingBlockTicker <- liftIO $ async $
+                tickDiffusionLayer
+                logging
+                tickDiffusionFunction
+                (([],headersConsumed), initialUtxo)
+
+            bracket
+                (return (activeWalletLayer w))
+                (\_ -> liftIO $ do
+                    logging Error "stopping the wallet applying block layer..."
+                    cancel applyingBlockTicker
+                )
+                (flip runActiveLayer w)
+         else do
+
+            liftIO $ logging Debug "push mechanism (readerT based) for block syncing is active"
+
+            bracket
+                (return (activeWalletLayer w))
+                (\_ -> return ())
+                (flip runActiveLayer w)
   where
     activeWalletLayer :: Kernel.ActiveWallet -> ActiveWalletLayer n
     activeWalletLayer w = ActiveWalletLayer {
@@ -172,3 +222,106 @@ bracketActiveWallet walletPassiveLayer passiveWallet walletDiffusion runActiveLa
         , submitSignedTx     = Active.submitSignedTx   w
         , redeemAda          = Active.redeemAda        w
         }
+
+    logging :: Severity -> Text -> IO ()
+    logging = passiveWallet ^. Kernel.walletLogMessage
+
+    tickDiffusionFunction
+        :: (Severity -> Text -> IO ())
+        -> (([HeaderHash], [HeaderHash]), Utxo)
+        -> IO (([HeaderHash], [HeaderHash]), Utxo)
+    tickDiffusionFunction log currentState@((inProgressHeaders, consumedHeaders),utxo) = do
+
+        nodeBlockHeaderMap <- walletRequestTip walletDiffusion
+
+        case (List.take 1 $ Map.toList nodeBlockHeaderMap, inProgressHeaders) of
+
+            ([(nodeId, _)], [h1, h2]) -> do
+                --downloading blocks
+                blocksDowloaded <- getOldestFirst <$> walletGetBlocks walletDiffusion nodeId h2 (take 1 consumedHeaders)
+
+                let accomodatedHeaders =  map (headerHash . getBlockHeader) $ blocksDowloaded
+
+                let prevHeaders = case consumedHeaders of
+                                      [] -> (take 1 accomodatedHeaders) ++ ((reverse . drop 1 . reverse) accomodatedHeaders)
+                                      cs -> (take 1 cs) ++ ((reverse . drop 1 . reverse) accomodatedHeaders)
+
+                let slotIdsM =  map createSlotIdM blocksDowloaded
+
+                let (txPayload, updatedUtxo) = foldl processBlockTx ([],utxo) blocksDowloaded
+
+                now <- getCurrentTimestamp
+
+                let context = List.zipWith3 createBlockContext (catMaybes slotIdsM) accomodatedHeaders prevHeaders
+
+                let resolvedTxs = map (payloadToResolved now) $ catMaybes txPayload
+
+                let resolvedBlocks = List.zipWith (createResolvedBlock now) resolvedTxs context
+
+                mapM_ (Kernel.applyBlock passiveWallet) resolvedBlocks
+
+                pure $ (([h1], (reverse accomodatedHeaders) ++ consumedHeaders), updatedUtxo)
+
+            ([(_, headerIO)],_) -> do
+                --collecting headers
+                headerHashE <- try ( headerHash <$> headerIO ) :: IO (Either SomeException HeaderHash)
+                case headerHashE of
+                    Right header -> do
+                        pure $ ((List.nub $ header : inProgressHeaders, consumedHeaders), utxo)
+                    Left exep -> do
+                        log Error (show exep)
+                        pure $ currentState
+
+            _ -> do
+                -- no communication
+                pure $ currentState
+            where
+                updateUtxo payload theUtxo =
+                    let utxoAfterAddition = utxoUnions $ theUtxo : (map (snd . snd) $ catMaybes payload)
+                        utxoSetToDel = Set.fromList $ concatMap fst (catMaybes payload)
+                    in  utxoRemoveInputs utxoAfterAddition utxoSetToDel
+
+                createBlockContext slotId header1 header2 =
+                    if (header1 == header2) then
+                        BlockContext (InDb $ slotId) (InDb $ header1) (StrictMaybe.Nothing)
+                    else
+                        BlockContext (InDb $ slotId) (InDb $ header1) (StrictMaybe.Just (InDb $ header2))
+
+                createResolvedTx txIn payload time =
+                    let resolvedTxIn = fst payload
+                        resolvedTxOut = (fst . snd) payload
+                        theUtxo = (snd . snd) payload
+                    in ResolvedTx (InDb $ NE.fromList $ zip resolvedTxIn resolvedTxOut) (InDb theUtxo) (InDb $ (txIn,time))
+
+                createResolvedBlock time resTx bCtx  =
+                    case resTx of
+                        Just resolvedTx ->
+                            let (_, timestamp) = _fromDb $ _rtxMeta resolvedTx
+                            in ResolvedBlock [resolvedTx] bCtx timestamp
+                        Nothing  ->
+                            ResolvedBlock [] bCtx time
+
+                createSlotIdM = (\case
+                                        Right block -> Just $ block ^. mainBlockSlot
+                                        Left _  -> Nothing
+                                )
+
+                processBlockTx (payloads,currentUtxo) theBlock =
+                    case theBlock of
+                        Right block ->
+                            let transactionsInBlock = block ^. mainBlockTxPayload . txpTxs
+                                outputs = utxoUnions $ map txOuts transactionsInBlock
+                                inputs = map _txInputs transactionsInBlock
+                                inputsToRemove = concatMap toList inputs
+                                findUtxo = utxoToLookup currentUtxo
+                                inputsE = concatMap ((mapMaybe findUtxo) . toList) inputs
+                                payloadToAdd = [Just (inputsToRemove, (inputsE, outputs))]
+                                updatedUtxo = updateUtxo payloadToAdd currentUtxo
+                            in (Just (inputsToRemove, (inputsE, outputs)) : payloads,updatedUtxo)
+                        Left _  -> (Nothing : payloads,currentUtxo)
+
+                payloadToResolved time = (\payload ->
+                                              case List.take 1 $ Map.keys ((snd . snd) payload) of
+                                                  [(TxInUtxo justOne _)]  -> Just $ createResolvedTx justOne payload time
+                                                  _ -> Nothing
+                                         )

--- a/test/integration/Test/Integration/Framework/Cluster.hs
+++ b/test/integration/Test/Integration/Framework/Cluster.hs
@@ -69,6 +69,7 @@ defaultIntegrationEnv = Map.fromList
     , ("NODE_TLS_CLIENT_CERT", "./state-integration/tls/relay/client.crt")
     , ("NODE_TLS_KEY", "./state-integration/tls/relay/client.key")
     , ("NODE_TLS_CA_CERT", "./state-integration/tls/relay/ca.crt")
+    , ("PULL_MECHANISM", "False")
     ]
 
 -- | Start an integration cluster. Quite identical to the original "start cluster".

--- a/test/integration/Test/Integration/Scenario/Transactions.hs
+++ b/test/integration/Test/Integration/Scenario/Transactions.hs
@@ -10,6 +10,7 @@ import           Test.Integration.Framework.DSL
 spec :: Scenarios Context
 spec = do
 
+
     scenario "proper fragmentation of utxo allows for multi-output transaction" $ do
         fixtureSource <- setup $ defaultSetup
             & initialCoins .~ [500000, 500000]

--- a/test/unit/Test/Spec/Kernel.hs
+++ b/test/unit/Test/Spec/Kernel.hs
@@ -302,4 +302,6 @@ diffusion :: Kernel.WalletDiffusion
 diffusion =  Kernel.WalletDiffusion {
       walletSendTx                = \_tx -> return False
     , walletGetSubscriptionStatus = return mempty
+    , walletRequestTip            = return mempty
+    , walletGetBlocks             = \_nodeId _hashId _checkpointHashIds -> return $ OldestFirst []
     }

--- a/test/unit/Test/Spec/TxMetaScenarios.hs
+++ b/test/unit/Test/Spec/TxMetaScenarios.hs
@@ -448,6 +448,8 @@ diffusion :: Kernel.WalletDiffusion
 diffusion =  Kernel.WalletDiffusion {
       walletSendTx = \_tx -> return False
     , walletGetSubscriptionStatus = return mempty
+    , walletRequestTip            = return mempty
+    , walletGetBlocks             = \_nodeId _hashId _checkpointHashIds -> return $ OldestFirst []
   }
 
 getSomeTimestamp :: Pos.Core.Timestamp


### PR DESCRIPTION
#88 

# Overview

- [x] I have added getBlocks and requestTip support in diffusion layer
- [x] The additional thread is instantiated that is responsible for downloading blocks from the node
- [x] The added mechanism is based on pull paradigm, ie., the wallet is the initiator for pulling blocks, makes sure the blocks are in line with what the node has
- [x] The same resolved blocks are created using the added mechanism as it is in case of old mechanism
- [x] apply blocks part of old mechanism is commented out  
- [x] I have handled a number of pathological cases, like corrupt data coming from the node or no communication with the node for some time 
- [x] Added `pull-mechanism` flag to switch on pull mechanism. Otherwise, push mechanism, the readerT based - well tested but introducing coupling, is used 

# Comments

The thorough description of the proposed mechanism are
[here](https://github.com/input-output-hk/cardano-wallet/wiki/ApplyingBlocks-Rollback-After-Decoupling-Byron) 

# Testing
## unit tests
When run as it is push mechanism is used as default. In order to run unit tests in **pull mechanism** first change in `test/unit/Test/Spec/Fixture.hs`:
```
41  usePullMechanism :: Bool                                                                                                                                                                  
42  usePullMechanism = True
```
and then 
```
$ stack test cardano-wallet:test:unit
```

## integration tests
In order to run integration tests using pull mechanism first change in `test/integration/Test/Integration/Framework/Cluster.hs` :
```
72      , ("PULL_MECHANISM", "True")
``` 
and then
```
$ stack test cardano-wallet:test:integration
```
One should see the following log in `edge.log.pub`:
```
[pawel@arch logs]$ ag "mechanism" edge.log.pub
43602:[cardano-sl.edge:Debug:ThreadId 1063] [2019-01-26 19:07:54.34 UTC] pull mechanism (diffusion layer based) for block syncing is active
```
In default case one should see instead : 
 ```
[pawel@arch logs]$ ag "mechanism" edge.log.pub
538:[cardano-sl.edge:Debug:ThreadId 1163] [2019-01-26 18:57:03.74 UTC] push mechanism (readerT based) for block syncing is active
```

## wallet-node syncing with mainnet
When running wallet with node attached to mainnet see [here](https://github.com/input-output-hk/cardano-wallet/wiki/Building-Running-and-Testing-a-wallet-node)
In order to switch on **pull mechanism** of block syncing use additionally `--pull-mechanism```
One should see the same logs as above confirming switching on the pull mechanism


A number of problems were solved during this PR:
**Update1**
Now after the metaTx fix coin selection tests in Transactions testsuite and Utxo test in Wallets testsuite are alright. Occasionally, I am witnessing the thread responsible for block application to be stuck (and then all tests that rely on block application fail) for the reason I do not understand at this moment. 

**Update 2**
I addressed those rare cases : it was due to (a) no communication with node, (b) corrupt data flowing from the node, (c) combination of (a) and (b). 
I tested using integration tests more than 100 - found all cases and handled them properly (ie., integration tests pass)
 
Very occasionally the node response of `requestTip` (from `lib/src/Pos/Diffusion/Full/Block.hs` from `cardano-sl`): 
```
479	    handleTip _ t = do
480	        traceWith logTrace (Warning, sformat ("requestTip: got enexpected response: "%shown) t)
481	        throwIO $ DialogUnexpected "peer sent more than one tip"
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
