### PR TITLE
Integration tests covering WALLETS_CREATE capability

### DIFF
--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -14,6 +14,7 @@ module Test.Integration.Framework.DSL
     , setup
     , request
     , request_
+    , successfulRequest
     , unsafeRequest
     , verify
 
@@ -69,9 +70,12 @@ module Test.Integration.Framework.DSL
     , initialCoins
     , mnemonicWords
     , wallet
+    , wallets
     , walletId
     , walletName
     , json
+    , hasSpendingPassword
+    , mkBackupPhrase
     ) where
 
 import           Universum hiding (getArgs, second)
@@ -298,8 +302,14 @@ initialCoins =
 mnemonicWords :: HasType [Text] s => Lens' s [Text]
 mnemonicWords = typed
 
+hasSpendingPassword :: HasType Bool s => Lens' s Bool
+hasSpendingPassword = typed
+
 wallet :: HasType Wallet s => Lens' s Wallet
 wallet = typed
+
+wallets :: HasType [Wallet] s => Lens' s [Wallet]
+wallets = typed
 
 walletId :: HasType WalletId s => Lens' s WalletId
 walletId = typed
@@ -329,7 +339,6 @@ expectFieldEqual getter a = \case
     Left e  -> wantedSuccessButError e
     Right s -> view getter s `shouldBe` a
 
-
 -- | Expects entire equality of two types
 expectEqual
     :: (MonadIO m, MonadFail m, Show a, Eq a)
@@ -338,7 +347,6 @@ expectEqual
     -> m ()
 expectEqual =
     expectFieldEqual id
-
 
 -- | Expect an errored response, without any further assumptions
 expectError
@@ -475,7 +483,6 @@ expectJSONError excerpt = \case
         T.unpack msg `shouldContain` excerpt
     Left e ->
         fail $ "expectJSONError: got something else than a JSON validation failure: " <> show e
-
 
 expectWalletUTxO
     :: (MonadIO m, MonadFail m)

--- a/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -10,35 +10,792 @@ import           Test.Integration.Framework.DSL
 
 spec :: Scenarios Context
 spec = do
-    scenario "demo unsafeRequest" $ do
-        fixture <- setup $ defaultSetup
 
-        let endpoint = "api" </> "v1" </> "wallets" </> fixture ^. wallet . walletId
-        response <- unsafeRequest ("PUT", endpoint) $ Just $ [json|{
-            "invalidField": #{fixture ^. wallet}
-        }|]
+    scenario "WALLETS_CREATE_01 - One can restore previously deleted wallet" $ do
+      fixture <- setup $ defaultSetup
+        & initialCoins .~ [1000111]
 
-        verify (response :: Either ClientError Wallet)
-            [ expectJSONError "key assuranceLevel was not present"
-            ]
+      -- 1. Delete wallet
+      successfulRequest $ Client.deleteWallet
+        $- (fixture ^. wallet . walletId)
 
-    scenario "wallet is available after it's been created" $ do
-        fixture <- setup $ defaultSetup
-            & walletName .~ "漢patate字"
-            & assuranceLevel .~ StrictAssurance
+      -- 1. Restore wallet
+      restoration <- request $ Client.postWallet $- NewWallet
+        (fixture ^. backupPhrase)
+        noSpendingPassword -- defaultSpendingPassword does not work
+        StrictAssurance
+        kanjiPolishWalletName
+        RestoreWallet
+      verify restoration
+        [ expectWalletEventuallyRestored
+        , expectFieldEqual walletName kanjiPolishWalletName
+        , expectFieldEqual assuranceLevel StrictAssurance
+        , expectFieldEqual hasSpendingPassword False
+        , expectFieldEqual amount 1000111
+        ]
 
-        response <- request $ Client.getWallet
-            $- (fixture ^. wallet . walletId)
+    scenario "WALLETS_CREATE_02a - Restore wallet with No spending password" $ do
+      -- 1. Setup new wallet
+      fixture <- setup $ defaultSetup
 
-        verify response
-            [ expectFieldEqual walletName "漢patate字"
-            , expectFieldEqual assuranceLevel StrictAssurance
-            ]
+      -- 2. Delete wallet
+      successfulRequest $ Client.deleteWallet
+        $- (fixture ^. wallet . walletId)
 
-    scenario "updating a wallet persists the update" $ do
+      -- 3. Restore wallet with noSpendingPassword
+      restoreResp <- request $ Client.postWallet $- NewWallet
+        (fixture ^. backupPhrase)
+        noSpendingPassword
+        StrictAssurance
+        kanjiPolishWalletName
+        RestoreWallet
+      verify restoreResp
+        [ expectWalletEventuallyRestored
+        , expectFieldEqual walletName kanjiPolishWalletName
+        , expectFieldEqual assuranceLevel StrictAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+      -- 4. Get wallet details
+      getResp <- request $ Client.getWallet
+        $- (fixture ^. wallet . walletId)
+      verify getResp
+        [
+          expectFieldEqual walletName kanjiPolishWalletName
+        , expectFieldEqual assuranceLevel StrictAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+    scenario "WALLETS_CREATE_02b - Create wallet with No spending password" $ do
+      -- 1. Create yet new wallet with noSpendingPassword
+      bkpPhrase <- mkBackupPhrase testBackupPhrase2
+      let newWalletName = "πœę©ß←↓→óþąśðæŋ’ə…łżźć„”ńµ"
+      createResp <- successfulRequest $ Client.postWallet $- NewWallet
+        bkpPhrase
+        noSpendingPassword
+        NormalAssurance
+        newWalletName
+        CreateWallet
+      verify (Right createResp)
+        [
+          expectFieldEqual walletName newWalletName
+        , expectFieldEqual assuranceLevel NormalAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+      -- 2. Verify noSpendingPassword on new wallet
+      getAgainResp <- request $ Client.getWallet
+        $- (createResp ^. walletId)
+      verify getAgainResp
+        [
+          expectFieldEqual walletName newWalletName
+        , expectFieldEqual assuranceLevel NormalAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+    scenario "WALLETS_CREATE_02c - Create wallet with spending password" $ do
+
+      createResp <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "My HODL Wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+      verify (createResp :: Either ClientError Wallet)
+        [
+          expectFieldEqual hasSpendingPassword True
+        , expectFieldEqual walletName "My HODL Wallet"
+        , expectFieldEqual assuranceLevel NormalAssurance
+        ]
+
+    scenario "WALLETS_CREATE_02d - Restore wallet with spending password" $ do
+
+      restoResp <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase2},
+        "assuranceLevel": "strict",
+        "name": "My HODL Wallet 2",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (restoResp :: Either ClientError Wallet)
+        [
+          expectWalletEventuallyRestored
+        , expectFieldEqual hasSpendingPassword True
+        , expectFieldEqual walletName "My HODL Wallet 2"
+        , expectFieldEqual assuranceLevel StrictAssurance
+        ]
+
+    scenario "WALLETS_CREATE_02e - Create wallet if spendingPassword is null" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "MyFirstWallet",
+        "spendingPassword": null
+      }|]
+      verify (response3 :: Either ClientError Wallet)
+        [
+          expectFieldEqual walletName "MyFirstWallet"
+        , expectFieldEqual assuranceLevel NormalAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+
+    scenario "WALLETS_CREATE_02f - Restore wallet if spendingPassword is null" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": null
+      }|]
+      verify (response3 :: Either ClientError Wallet)
+        [
+          expectFieldEqual walletName "MyFirstWallet"
+        , expectFieldEqual assuranceLevel StrictAssurance
+        , expectFieldEqual hasSpendingPassword False
+        ]
+
+    scenario "WALLETS_CREATE_03a - Cannot create wallet if spendingPassword is hex|base16 string with length less than 64" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "MyFirstWallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c6"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: Expected spending password to be of either length 0 or 32, not 26"
+        ]
+
+    scenario "WALLETS_CREATE_03b - Cannot restore wallet if spendingPassword is hex|base16 string with length less than 64" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "MyFirstWallet",
+        "spendingPassword": "541"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "suffix is not in base-16 format: 1"
+        ]
+
+    scenario "WALLETS_CREATE_03c - Cannot create wallet if spendingPassword is hex|base16 string with length MORE than 64" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "MyFirstWallet",
+        "spendingPassword": "c0b75cebcd14403d7abba4227cea5b99b1b09148623cd927fa7bb40c6cca5583c"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format: c"
+        ]
+
+    scenario "WALLETS_CREATE_03d - Cannot restore wallet if spendingPassword is hex|base16 string with length MORE than 64" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "MyFirstWallet",
+        "spendingPassword": "c0b75cebcd14403d7abba4227cea5b99b1b09148623cd927fa7bb40c6cca5583c"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format: c"
+        ]
+
+    scenario "WALLETS_CREATE_03e - Cannot create wallet if spendingPassword is number" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": 541
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: expected parseJSON failed for PassPhrase, encountered Number"
+        ]
+
+    scenario "WALLETS_CREATE_03f - Cannot create wallet if spendingPassword is array" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": []
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: expected parseJSON failed for PassPhrase, encountered Array"
+        ]
+
+    scenario "WALLETS_CREATE_03g - Cannot create wallet if spendingPassword is empty string" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": " "
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format"
+        ]
+
+    scenario "WALLETS_CREATE_03h - Cannot restore wallet if spendingPassword is number" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": 541
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: expected parseJSON failed for PassPhrase, encountered Number"
+        ]
+
+    scenario "WALLETS_CREATE_03i - Cannot restore wallet if spendingPassword is array" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": []
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: expected parseJSON failed for PassPhrase, encountered Array"
+        ]
+
+    scenario "WALLETS_CREATE_03j - Cannot restore wallet if spendingPassword is empty string" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": " "
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format"
+        ]
+
+    scenario "WALLETS_CREATE_03j - Cannot create wallet if spendingPassword is a string" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": "patate"
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format"
+        ]
+
+    scenario "WALLETS_CREATE_03k - Cannot restore wallet if spendingPassword is a string" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": "MyFirstWallet",
+        "spendingPassword": "patate"
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.spendingPassword: suffix is not in base-16 format"
+        ]
+
+    scenario "WALLETS_CREATE_04 - Cannot perform operation other than 'create' or 'restore'" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": #{russianWalletName},
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.operation: When parsing Cardano.Wallet.API.V1.Types.WalletOperation expected a String with the tag of a constructor but got"
+        ]
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+          [ expectJSONError "Error in $.operation: When parsing Cardano.Wallet.API.V1.Types.WalletOperation expected a String with the tag of a constructor but got"
+          ]
+
+    scenario "WALLETS_CREATE_05a - can't create wallet if backupPhrase is already known" $ do
+      fixture <- setup $ defaultSetup
+
+      response <- request $ Client.postWallet $- NewWallet
+        (fixture ^. backupPhrase)
+        noSpendingPassword
+        defaultAssuranceLevel
+        defaultWalletName
+        CreateWallet
+
+      verify response
+        [ expectWalletError (WalletAlreadyExists (fixture ^. wallet . walletId))
+        ]
+
+    scenario "WALLETS_CREATE_05b - can't restore wallet if backupPhrase is already known" $ do
+      fixture <- setup $ defaultSetup
+        & mnemonicWords .~ testBackupPhrase
+
+      response <- request $ Client.postWallet $- NewWallet
+        (fixture ^. backupPhrase)
+        noSpendingPassword
+        defaultAssuranceLevel
+        defaultWalletName
+        RestoreWallet
+
+      verify response
+        [ expectWalletError (WalletAlreadyExists (fixture ^. wallet . walletId))
+        ]
+
+    scenario "WALLETS_CREATE_06, WALLETS_CREATE_12a - wallet is available after it's been created - long wallet name" $ do
+      fixture <- setup $ defaultSetup
+        & walletName .~ longWalletName
+        & assuranceLevel .~ StrictAssurance
+
+      response <- request $ Client.getWallet
+        $- (fixture ^. wallet . walletId)
+
+      verify response
+        [
+          expectFieldEqual walletName longWalletName
+        , expectFieldEqual assuranceLevel StrictAssurance
+        ]
+
+    scenario "WALLETS_CREATE_06, WALLETS_CREATE_12b - wallet is available after it's been created - empty wallet name" $ do
+      fixture <- setup $ defaultSetup
+        & walletName .~ ""
+        & assuranceLevel .~ NormalAssurance
+
+      response <- request $ Client.getWallet
+        $- (fixture ^. wallet . walletId)
+
+      verify response
+        [ expectFieldEqual walletName ""
+        , expectFieldEqual assuranceLevel NormalAssurance
+        ]
+
+    scenario "WALLETS_CREATE_07a - Cannot create wallet using LESS than 12 mnemonics valid BIP-39" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{mnemonicsWith9Words},
+        "assuranceLevel": "strict",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Invalid number of mnemonic words: got 9 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_07b - Cannot restore wallet using LESS than 12 mnemonics valid BIP-39" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{mnemonicsWith9Words},
+        "assuranceLevel": "strict",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Invalid number of mnemonic words: got 9 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_07c - Cannot create wallet using empty mnemonics list" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": [],
+        "assuranceLevel": "normal",
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Invalid number of mnemonic words: got 0 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_07d - Cannot restore wallet using empty mnemonics list" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": [],
+        "assuranceLevel": "normal",
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "Invalid number of mnemonic words: got 0 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_07e - Cannot create wallet using MORE than 12 mnemonics valid BIP-39" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{mnemonicsWith15Words},
+        "assuranceLevel": "strict",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Invalid number of mnemonic words: got 15 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_07f - Cannot restore wallet using MORE than 12 mnemonics valid BIP-39" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{mnemonicsWith15Words},
+        "assuranceLevel": "strict",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: MnemonicError: Invalid number of mnemonic words: got 15 words, expected 12 words"
+        ]
+
+    scenario "WALLETS_CREATE_08a - Cannot create wallet using valid non-English mnemonics" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{kanjiMnemonics},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: MnemonicError: Invalid dictionary word:"
+        ]
+
+    scenario "WALLETS_CREATE_08b - Cannot restore wallet using valid non-English mnemonics" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{kanjiMnemonics},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: MnemonicError: Invalid dictionary word:"
+        ]
+
+    scenario "WALLETS_CREATE_08c - Cannot create wallet using invalid mnemonics" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{invalidMnemonics},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: MnemonicError: Invalid entropy checksum: got Checksum 11, expected Checksum 5"
+        ]
+
+    scenario "WALLETS_CREATE_08d - Cannot restore wallet using invalid mnemonics" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{invalidMnemonics},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: MnemonicError: Invalid entropy checksum: got Checksum 11, expected Checksum 5"
+        ]
+
+    scenario "WALLETS_CREATE_09a - Cannot create wallet with mnemonics from the API doc" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{apiDocsBackupPhrase},
+        "assuranceLevel": "strict",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: Forbidden Mnemonic: an example Mnemonic has been submitted. Please generate a fresh and private Mnemonic from a trusted source"
+        ]
+
+    scenario "WALLETS_CREATE_09b - Cannot restore wallet with mnemonics from the API doc" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{apiDocsBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.backupPhrase: Forbidden Mnemonic: an example Mnemonic has been submitted. Please generate a fresh and private Mnemonic from a trusted source"
+        ]
+
+    scenario "WALLETS_CREATE_10a - Cannot create wallet with assurance level other than 'strict' or 'normal'" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": #{russianWalletName},
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.assuranceLevel: When parsing Cardano.Wallet.API.V1.Types.AssuranceLevel expected a String with the tag of a constructor but got"
+        ]
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.assuranceLevel: When parsing Cardano.Wallet.API.V1.Types.AssuranceLevel expected a String with the tag of a constructor but got"
+        ]
+
+    scenario "WALLETS_CREATE_10b - Cannot restore wallet with assurance level other than 'strict' or 'normal'" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": #{russianWalletName},
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.assuranceLevel: When parsing Cardano.Wallet.API.V1.Types.AssuranceLevel expected a String with the tag of a constructor but got"
+        ]
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "",
+        "name": #{russianWalletName},
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "Error in $.assuranceLevel: When parsing Cardano.Wallet.API.V1.Types.AssuranceLevel expected a String with the tag of a constructor but got"
+        ]
+
+    scenario "WALLETS_CREATE_11a - Cannot perform POST to api/v1/wallets without all required parameters (operation)" $ do
+
+      response <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal",
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key operation was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11b - Cannot perform create without all required parameters (backupPhrase)" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "assuranceLevel": "normal",
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key backupPhrase was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11c - Cannot perform restore without all required parameters (backupPhrase)" $ do
+
+      response2 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "assuranceLevel": "normal",
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+      verify (response2 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key backupPhrase was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11d - Cannot perform create without all required parameters (assuranceLevel)" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key assuranceLevel was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11e - Cannot perform restore without all required parameters (assuranceLevel)" $ do
+
+      response3 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "name": "my hodl wallet",
+        "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0"
+      }|]
+
+
+      verify (response3 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key assuranceLevel was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11f - Cannot perform create without all required parameters (name)" $ do
+
+      response4 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "create",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal"
+      }|]
+
+      verify (response4 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key name was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11g - Cannot perform restore without all required parameters (name)" $ do
+
+      response4 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "operation": "restore",
+        "backupPhrase": #{testBackupPhrase},
+        "assuranceLevel": "normal"
+      }|]
+
+      verify (response4 :: Either ClientError Wallet)
+        [ expectJSONError "When parsing the record newWallet of type Cardano.Wallet.API.V1.Types.NewWallet the key name was not present."
+        ]
+
+    scenario "WALLETS_CREATE_11h - Cannot perform POST to api/v1/wallets with invalid parameters" $ do
+
+      response5 <- unsafeRequest ("POST", "api/v1/wallets") $ Just $ [json|{
+        "Invalid1": "param",
+        "Invalid2": "param",
+        "Invalid3": "param"
+      }|]
+
+      verify (response5 :: Either ClientError Wallet)
+        [ expectJSONError "key backupPhrase was not present"
+        ]
+
+    scenario "WALLETS_DELETE_01 - deleted wallet is not available" $ do
+      fixture <- setup $ defaultSetup
+        & walletName .~ "漢ę ó ł ąś ł żźćń字"
+        & mnemonicWords .~ testBackupPhrase
+
+      successfulRequest $ Client.deleteWallet
+        $- (fixture ^. wallet . walletId)
+
+      response02 <- request $ Client.getWallet
+        $- (fixture ^. wallet . walletId)
+
+      verify response02
+        [ expectWalletError (WalletNotFound)
+        ]
+
+    scenario "WALLETS_LIST_01 - One can list all wallets without providing any parameters" $ do
+      -- 1. Create 3 wallets
+      fixture01 <- setup $ defaultSetup
+        & walletName .~ "1"
+        & assuranceLevel .~ NormalAssurance
+
+      fixture02 <- setup $ defaultSetup
+        & walletName .~ "2"
+        & assuranceLevel .~ NormalAssurance
+
+      fixture03 <- setup $ defaultSetup
+        & walletName .~ "3"
+        & assuranceLevel .~ StrictAssurance
+
+      getResp01 <- request $ Client.getWallet
+        $- (fixture01 ^. wallet . walletId)
+      verify getResp01
+        [ expectFieldEqual walletName "1"
+        , expectFieldEqual assuranceLevel NormalAssurance
+        ]
+
+      getResp02 <- request $ Client.getWallet
+        $- (fixture02 ^. wallet . walletId)
+      verify getResp02
+        [ expectFieldEqual walletName "2"
+        , expectFieldEqual assuranceLevel NormalAssurance
+        ]
+
+      getResp03 <- request $ Client.getWallet
+         $- (fixture03 ^. wallet . walletId)
+      verify getResp03
+         [ expectFieldEqual walletName "3"
+         , expectFieldEqual assuranceLevel StrictAssurance
+         ]
+
+      getWalletsResp <- request $ Client.getWallets
+      verify getWalletsResp
+        [ expectSuccess
+        -- additional checks need to be added
+        -- expect returned list of wallets has size 3
+        -- expect there is a wallet on the list with certain field value
+        ]
+
+
+    scenario "WALLETS_UPDATE_01 - updating a wallet persists the update" $ do
         fixture <- setup defaultSetup
 
-        [_, response] <- sequence
+        [_, response01] <- sequence
             [ request $ Client.updateWallet
                 $- (fixture ^. wallet . walletId)
                 $- WalletUpdate StrictAssurance "漢patate字"
@@ -46,12 +803,12 @@ spec = do
                 $- (fixture ^. wallet . walletId)
             ]
 
-        verify response
+        verify response01
             [ expectFieldEqual walletName "漢patate字"
             , expectFieldEqual assuranceLevel StrictAssurance
             ]
 
-    scenario "UTxO statistics reflect wallet's inactivity" $ do
+    scenario "WALLETS_UTXO_03 - UTxO statistics reflect wallet's inactivity" $ do
         fixture <- setup defaultSetup
 
         response <- request $ Client.getUtxoStatistics
@@ -61,7 +818,7 @@ spec = do
             [ expectWalletUTxO []
             ]
 
-    scenario "UTxO statistics reflect wallet's activity" $ do
+    scenario "WALLETS_UTXO_04 - UTxO statistics reflect wallet's activity" $ do
         fixture <- setup $ defaultSetup
             & initialCoins .~ [14, 42, 1337]
 
@@ -72,37 +829,48 @@ spec = do
             [ expectWalletUTxO [14, 42, 1337]
             ]
 
-    scenario "can't create wallet if backupPhrase is already known" $ do
-        fixture <- setup $ defaultSetup
-            & mnemonicWords .~ testBackupPhrase
 
-        response <- request $ Client.postWallet $- NewWallet
-            (fixture ^. backupPhrase)
-            noSpendingPassword
-            defaultAssuranceLevel
-            defaultWalletName
-            CreateWallet
-
-        verify response
-            [ expectWalletError (WalletAlreadyExists (fixture ^. wallet . walletId))
-            ]
-
-    scenario "can't restore wallet if backupPhrase is already known" $ do
-        fixture <- setup $ defaultSetup
-            & mnemonicWords .~ testBackupPhrase
-
-        response <- request $ Client.postWallet $- NewWallet
-            (fixture ^. backupPhrase)
-            noSpendingPassword
-            defaultAssuranceLevel
-            defaultWalletName
-            RestoreWallet
-
-        verify response
-            [ expectWalletError (WalletAlreadyExists (fixture ^. wallet . walletId))
-            ]
   where
     testBackupPhrase :: [Text]
     testBackupPhrase =
         ["clap", "panda", "slim", "laundry", "more", "vintage", "cash", "shaft"
         , "token", "history", "misery", "problem"]
+
+    testBackupPhrase2 :: [Text]
+    testBackupPhrase2 =
+        ["minute", "young", "render", "bench", "butter", "captain", "runway"
+        , "summer", "naive", "rally", "viable", "master"]
+
+    apiDocsBackupPhrase :: [Text]
+    apiDocsBackupPhrase =
+        ["squirrel", "material", "silly", "twice", "direct", "slush", "pistol", "razor"
+         , "become", "junk", "kingdom", "flee"]
+
+    invalidMnemonics :: [Text]
+    invalidMnemonics =
+        ["clinic","nuclear","paddle","leg","lounge","fabric","claw","trick"
+        ,"divide","pretty","argue","master"]
+
+    kanjiMnemonics :: [Text]
+    kanjiMnemonics =
+        ["けぬき", "つごう", "ちかい",　"いみん",　"よしゅう",　"ついたち",　"だっかい"
+        ,　"くたびれる",　"はんとし",　"けしょう",　"すうじつ",　"てそう"]
+
+    mnemonicsWith9Words :: [Text]
+    mnemonicsWith9Words =
+        ["pave", "behind", "simple", "lobster", "digital", "ready", "switch"
+        , "uncle", "dragon"]
+
+    mnemonicsWith15Words :: [Text]
+    mnemonicsWith15Words =
+        ["organ", "uniform", "anchor", "exhibit", "satisfy", "scrub", "vacant"
+        , "hold", "spawn", "super", "tenant", "change", "illegal", "yard", "quarter"]
+
+    kanjiPolishWalletName :: Text
+    kanjiPolishWalletName = "亜哀愛悪握圧扱安暗案以位依偉囲委 威尉意慰易為異移維緯胃衣違遺医井域育一壱逸稲芋印員因 姻引飲院陰隠韻右宇羽雨\n渦浦運雲営影映栄永泳英衛詠鋭液疫益駅悦 謁越閲円園宴延援沿演炎煙猿縁遠鉛塩 汚凹央奥往応押横欧殴王翁黄沖億屋憶乙卸恩温穏音下化仮何価佳加可夏嫁家寡科暇果架歌河火禍稼箇花荷華菓課貨過蚊我画芽賀雅餓介会解回塊壊快怪悔懐戒拐改械海灰界皆絵開階貝劾外害慨概涯街該垣嚇各拡格核殻獲確穫覚角較郭閣隔革学岳楽額掛潟割喝括活渇滑褐轄且株刈乾冠寒刊勘勧巻喚堪完官寛干幹患感慣憾換敢棺款歓汗漢環甘監看管簡緩缶肝艦観貫還鑑間閑関陥館丸含岸眼岩頑顔願企危喜器基奇寄岐希幾忌揮机旗既期棋棄機帰気汽祈季紀規記貴起軌輝飢騎鬼偽儀宜戯技擬欺犠疑義議菊吉喫詰却客脚虐逆丘久休及吸宮弓急救朽求泣球究窮級糾給旧牛去居巨拒拠\n挙虚許距漁魚享京供競共凶協叫境峡強恐恭挟教橋況狂狭矯胸脅興郷鏡響驚仰凝暁業局曲極玉勤均斤琴 禁筋緊菌襟謹近金吟銀九句区苦駆具愚虞空偶遇隅屈掘靴繰桑勲君薫訓群軍郡係傾刑兄啓型契形径恵慶憩掲携敬景渓系経継茎蛍計警軽鶏芸迎鯨劇撃激傑欠決潔穴結血月件倹健兼券剣圏堅嫌建憲懸検権犬献研絹県肩見謙賢軒遣険顕験元原厳幻弦減源玄現言限個古呼固孤己庫弧戸故枯湖誇雇顧鼓五互午呉娯後御悟碁語誤護交侯候光公功効厚口向后坑好孔孝工巧幸広康恒慌抗拘控攻更校構江洪港溝甲皇硬稿紅絞綱耕考肯航荒行衡講貢購郊酵鉱鋼降項香高剛号合拷豪克刻告国穀酷黒獄腰骨込今困墾婚恨懇昆根混紺魂佐唆左差査砂詐鎖座債催再最妻宰彩才採栽歳済災砕祭斎細菜裁載際剤在材罪財坂咲崎作削搾昨策索錯桜冊刷察撮擦札殺雑皿三傘参山惨散桟産算蚕賛酸暫残仕伺 使刺司史嗣四士始姉姿子市師志思指支施旨枝止死氏祉私糸紙紫肢脂至視詞詩試誌諮資賜雌飼歯事似侍児字寺慈持時次滋治璽磁示耳自辞式識軸七執失室湿漆疾質実芝舎写射捨赦斜煮社者謝車遮蛇邪借勺尺爵酌釈若寂弱主取守手朱殊狩珠種趣酒首儒受寿授樹需囚収周宗就州修愁拾秀秋終習臭舟衆襲週酬集醜住充十従柔汁渋獣縦重銃叔宿淑祝縮粛塾熟出術述俊春瞬准循旬殉準潤盾純巡遵順処初所暑庶緒署書諸助叙女序徐除傷償勝匠升召商唱奨宵将小少尚床彰承抄招掌昇昭晶松沼消渉焼焦照症省硝礁祥\r\n称章笑粧紹肖衝訟証詔詳象賞鐘障上丈乗冗剰城場壌嬢常\n情条浄状畳蒸譲醸錠嘱飾植殖織職ęó ąśł żźćń色触食辱伸信侵唇娠寝審心慎振新森浸深申真神紳臣薪親診身辛進針震人仁刃尋甚 尽迅陣酢図吹垂帥推水炊睡粋衰遂酔錘随髄崇数枢据杉澄寸世瀬畝是制勢姓征性成政整星晴正清牲生盛精聖声製西誠誓請逝青静斉税隻席惜斥昔析石積籍績責赤跡切拙接摂折設窃節説雪絶舌仙先千占宣専川戦扇栓泉浅洗染潜旋線繊船薦践選遷銭銑鮮前善漸然全禅繕塑措疎礎祖租粗素組訴阻僧創双倉喪壮奏層想捜掃挿操早曹巣槽燥争相窓総草荘葬藻装走送遭霜騒像増憎臓蔵贈造促側則即息束測足速俗属賊族続卒存孫尊損村他多太堕妥惰打駄体対耐帯待怠態替泰滞胎袋貸退逮隊代台大第題滝卓宅択拓沢濯託濁諾但達奪脱棚谷丹単嘆担探淡炭短端胆誕鍛団壇弾断暖段男談値知地恥池痴稚置致遅築畜竹蓄逐秩窒茶嫡着中仲宙忠抽昼柱注虫衷鋳駐著貯丁兆帳庁弔張彫徴懲挑朝潮 町眺聴脹腸調超跳長頂鳥勅直朕沈珍賃鎮陳津墜追痛通塚漬坪釣亭低停偵貞呈堤定帝底庭廷弟抵提程締艇訂逓邸泥摘敵滴的笛適哲徹撤迭鉄典天展店添転点伝殿田電吐塗徒斗渡登途都努度土奴怒倒党冬凍刀唐塔島悼投搭東桃棟盗湯灯当痘等答筒糖統到討謄豆踏逃透陶頭騰闘働動同堂導洞童胴道銅峠匿得徳特督篤毒独読凸突届屯豚曇鈍内縄南軟難二尼弐肉日乳入如尿任妊忍認寧猫熱年念燃粘悩濃納能脳農把覇波派破婆馬俳廃拝排敗杯背肺輩配倍培媒梅買売賠陪伯博拍泊白舶薄迫漠爆 縛麦箱肌畑八鉢発髪伐罰\n抜閥伴判半反帆搬板版犯班畔繁般藩販範煩頒飯晩番盤蛮卑否妃彼悲扉批披比泌疲皮碑秘罷肥 被費避非飛備尾微美鼻匹必筆姫百俵標氷漂票表評描病秒苗品浜貧賓頻敏 瓶不付夫婦富布府怖扶敷普浮父符腐膚譜負賦赴附侮武舞部封風伏副復幅服福腹複覆払沸仏物分噴墳憤奮粉紛雰文聞丙併兵塀幣平弊柄並閉陛米壁癖別偏変片編辺返遍便勉弁保舗捕歩補穂募墓慕暮母簿倣俸包報奉宝峰崩抱放方法泡砲縫胞芳褒訪豊邦飽乏亡傍剖坊妨帽忘忙房暴望某棒冒紡肪膨謀貿防北僕墨撲朴牧没堀奔本翻凡盆摩磨魔麻埋妹枚毎幕膜又抹末繭万慢満漫味未魅岬密脈妙民眠務夢無矛霧婿名命明盟迷銘鳴滅免綿面模茂妄毛猛盲網耗木黙目戻問紋門匁夜野矢厄役約薬訳躍柳愉油癒諭輸唯優勇友幽悠憂有猶由裕誘遊郵雄融夕予余与誉預幼容庸揚揺擁曜様洋溶用窯羊葉要謡踊陽養抑欲浴翌翼羅裸来頼雷絡落酪乱卵欄濫覧利吏履理痢裏里離陸律率立略流留硫粒隆 竜慮旅虜了僚両寮料涼猟療糧良量陵領力緑倫厘林臨輪隣塁涙累類令例冷励礼鈴隷零霊麗齢暦歴列劣烈裂廉恋練連錬炉路露労廊朗楼浪漏老郎六録論和話賄惑枠湾腕"
+
+    longWalletName :: Text
+    longWalletName = mconcat $ replicate 1000 kanjiPolishWalletName
+
+    russianWalletName :: Text
+    russianWalletName = "АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоПпРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯяІѢѲѴѵѳѣі"


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#172</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Added integration tests covering WALLETS_CREATE capability from [Capabilities & Requirements](https://docs.google.com/spreadsheets/d/1ztF2PnnrMnkAxrhdq3LUbP1KazxcxuMrbiObTs1CuTk) document
- [x] Failed attempt to create `expectJSONSuccess` to be used similar as as `expectJSONError`. But will go back to that later (in the next PR).


# Comments
Method mentioned above that I was not able to add:
```
-- Would be nice to have this method. The one commented above does not compile.
-- `T.unpack` is `Text - > String` and  a is `a rigid type variable bound by the type signature  for: expectJSONSuccess...`
expectJSONSuccess
	:: (MonadIO m, MonadFail m, Show a)
	=> String
	-> Either ClientError a
	-> m ()
expectJSONSuccess excerpt = \case
	Left e  -> wantedSuccessButError e
	Right a -> T.unpack a `shouldContain` excerpt
```
<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
