### PR TITLE
Remove 'WalletId' & 'AccountId' wrappers

### DIFF
--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -49,7 +49,6 @@ import           Cardano.Wallet.Kernel.Read (foreignPendingByAccount,
                      getWalletCredentials, getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Restore
 import qualified Cardano.Wallet.Kernel.Submission as Submission
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 import           Cardano.Wallet.Kernel.Util.NonEmptyMap (NonEmptyMap)
 import qualified Cardano.Wallet.Kernel.Util.NonEmptyMap as NEM
 import           Cardano.Wallet.WalletLayer.Kernel.Wallets
@@ -330,9 +329,7 @@ switchToFork pw@PassiveWallet{..} oldest bs = do
         -- Find any new restorations that we didn't know about.
         restorationInfo <- currentRestorations pw
         let restorations  = Map.elems   restorationInfo
-            restoringWals = Set.fromList $
-              Map.keys restorationInfo <&> \case
-                WalletIdHdRnd rootId -> rootId
+            restoringWals = Map.keysSet restorationInfo
         -- Stop the restorations.
         mapM_ cancelRestoration restorations
         -- Switch to the fork, retrying if another restoration begins in the meantime.

--- a/src/Cardano/Wallet/Kernel/DB/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Read.hs
@@ -38,14 +38,13 @@ import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
 import           Cardano.Wallet.Kernel.DB.Util.AcidState
 import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed, IxSet)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 
 {-------------------------------------------------------------------------------
   Getters across the entire kernel
 -------------------------------------------------------------------------------}
 
-walletIds :: DB -> [WalletId]
-walletIds db = map (WalletIdHdRnd . view hdRootId)
+walletIds :: DB -> [HdRootId]
+walletIds db = map (view hdRootId)
              $ IxSet.toList
              $ db ^. dbHdWallets . hdWalletsRoots
 

--- a/src/Cardano/Wallet/Kernel/Pending.hs
+++ b/src/Cardano/Wallet/Kernel/Pending.hs
@@ -33,7 +33,6 @@ import           Cardano.Wallet.Kernel.Internal
 import           Cardano.Wallet.Kernel.PrefilterTx (filterOurs)
 import           Cardano.Wallet.Kernel.Read (getWalletCredentials)
 import           Cardano.Wallet.Kernel.Submission (Cancelled, addPending)
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 import           Cardano.Wallet.Kernel.Util.Core
 
 {-------------------------------------------------------------------------------
@@ -99,7 +98,7 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
         Right () -> do
             -- process transaction on success
             -- myCredentials should be a list with a single element.
-            let myCredentials = filter (\(WalletIdHdRnd hdRoot, _) -> accountId ^. hdAccountIdParent == hdRoot) allCredentials
+            let myCredentials = filter (\(hdRoot, _) -> accountId ^. hdAccountIdParent == hdRoot) allCredentials
                 ourOutputCoins = snd <$> allOurs myCredentials
                 gainedOutputCoins = sumCoinsUnsafe ourOutputCoins
                 allOutsOurs = length ourOutputCoins == length txOut
@@ -112,10 +111,10 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
 
         -- | NOTE: we recognise addresses in the transaction outputs that belong to _all_ wallets,
         --  not only for the wallet to which this transaction is being submitted
-        allOurs :: [(WalletId, EncryptedSecretKey)] -> [(HdAddress,Coin)]
+        allOurs :: [(HdRootId, EncryptedSecretKey)] -> [(HdAddress,Coin)]
         allOurs = concatMap ourAddrs
 
-        ourAddrs :: (WalletId, EncryptedSecretKey) -> [(HdAddress,Coin)]
+        ourAddrs :: (HdRootId, EncryptedSecretKey) -> [(HdAddress,Coin)]
         ourAddrs (wid, esk) =
             map f $ filterOurs wKey txOutAddress txOut
             where

--- a/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -64,8 +64,7 @@ import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.Pending (PartialTxMeta, newForeign,
                      newPending)
 import           Cardano.Wallet.Kernel.Read (getWalletSnapshot)
-import           Cardano.Wallet.Kernel.Types (AccountId (..),
-                     RawResolvedTx (..), WalletId (..))
+import           Cardano.Wallet.Kernel.Types (RawResolvedTx (..))
 import           Cardano.Wallet.Kernel.Util.Core
 import           Cardano.Wallet.WalletLayer.Kernel.Conv (exceptT)
 import           Pos.Chain.Txp (Tx (..), TxAttributes, TxAux (..), TxId,
@@ -417,7 +416,7 @@ newTransaction aw@ActiveWallet{..} spendingPassword options accountId payees = d
              -- STEP 1: Perform the signing and forge the final TxAux.
              mbEsk <- liftIO $ Keystore.lookup
                         nm
-                        (WalletIdHdRnd $ accountId ^. hdAccountIdParent)
+                        (accountId ^. hdAccountIdParent)
                         (walletPassive ^. Internal.walletKeystore)
 
              -- STEP 2: Generate the change addresses needed.
@@ -709,7 +708,7 @@ redeemAda w@ActiveWallet{..} accId pw rsk = runExceptT $ do
     changeAddr <- withExceptT RedeemAdaErrorCreateAddressFailed $ ExceptT $ liftIO $
                     Kernel.createAddress
                       pw
-                      (AccountIdHdRnd accId)
+                      accId
                       walletPassive
     (tx, meta) <- mkTx pm changeAddr
     withExceptT RedeemAdaNewForeignFailed $ ExceptT $ liftIO $
@@ -783,7 +782,7 @@ genChangeOuts changeCoins srcAccountId spendingPassword walletPassive =
                   => ExceptT Kernel.CreateAddressError m Address
     genChangeAddr = ExceptT $ liftIO $
         Kernel.createAddress spendingPassword
-                             (AccountIdHdRnd srcAccountId)
+                             srcAccountId
                              walletPassive
 
 {-------------------------------------------------------------------------------

--- a/src/Cardano/Wallet/Kernel/Types.hs
+++ b/src/Cardano/Wallet/Kernel/Types.hs
@@ -10,10 +10,6 @@ module Cardano.Wallet.Kernel.Types (
   , RawResolvedBlock(..)
   , invRawResolvedBlock
   , mkRawResolvedBlock
-  -- ** Abstract Wallet/AccountIds
-  , WalletId (..)
-  , AccountId (..)
-  , accountToWalletId
     -- ** From raw to derived types
   , fromRawResolvedTx
   , fromRawResolvedBlock
@@ -22,65 +18,16 @@ module Cardano.Wallet.Kernel.Types (
 import           Universum
 
 import qualified Data.List.NonEmpty as NE
-import           Formatting.Buildable (Buildable (..))
 
 import           Pos.Chain.Block (MainBlock, gbBody, mbTxs, mbWitnesses)
 import           Pos.Chain.Txp (Tx, TxAux (..), TxId, TxIn (..), txInputs)
 import qualified Pos.Core as Core
 
-import           Formatting (bprint, (%))
-import qualified Formatting as F
-
 import           Cardano.Wallet.Kernel.DB.BlockContext
-import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Resolved
 import qualified Cardano.Wallet.Kernel.Util.Core as Core
 
-{-------------------------------------------------------------------------------
-  Abstract WalletId and AccountId
--------------------------------------------------------------------------------}
-
--- | Wallet Id
---
--- A Wallet Id can take several forms, the simplest of which is a hash
--- of the Wallet public key
-data WalletId =
-    -- | HD wallet with randomly generated addresses
-  WalletIdHdRnd HD.HdRootId
-
-    {- potential future kinds of wallet IDs:
-    -- | HD wallet with sequentially generated addresses
-    | WalletIdHdSeq ...
-
-    -- | External wallet (all crypto done off-site, like hardware wallets)
-    | WalletIdExt ...
-    -}
-
-    deriving (Eq, Ord, Generic)
-
-instance NFData WalletId
-
-instance Buildable WalletId where
-    build (WalletIdHdRnd rootId) =
-        bprint ("WalletIdHdRnd " % F.build) rootId
-
-accountToWalletId :: HD.HdAccountId -> WalletId
-accountToWalletId accountId
-    = WalletIdHdRnd $ accountId ^. HD.hdAccountIdParent
-
--- | Account Id
---
--- An Account Id can take several forms, the simplest of which is a
--- random-indexed, hardeded HD Account.
-data AccountId =
-    -- | HD wallet with randomly generated (hardened) index.
-    AccountIdHdRnd HD.HdAccountId
-    deriving (Eq, Ord)
-
-instance Buildable AccountId where
-    build (AccountIdHdRnd accountId) =
-        bprint ("AccountIdHdRnd " % F.build) accountId
 
 {-------------------------------------------------------------------------------
   Input resolution: raw types

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
@@ -29,7 +29,6 @@ import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed (..), IxSet)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import qualified Cardano.Wallet.Kernel.Read as Kernel
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 import           Cardano.Wallet.WalletLayer (CreateAccountError (..),
                      DeleteAccountError (..), GetAccountError (..),
                      GetAccountsError (..), UpdateAccountError (..))
@@ -49,7 +48,7 @@ createAccount wallet wId (V1.NewAccount mbSpendingPassword accountName) = liftIO
     (db, acc) <- withExceptT CreateAccountError $ ExceptT $ liftIO $
                      Kernel.createAccount passPhrase
                                           (HD.AccountName accountName)
-                                          (WalletIdHdRnd rootId)
+                                          rootId
                                           wallet
     let accId = acc ^. HD.hdAccountId
     let accountAddresses = addressesByAccountId db accId

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
@@ -26,7 +26,6 @@ import           Cardano.Wallet.Kernel.DB.Util.IxSet (AutoIncrementKey (..),
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import qualified Cardano.Wallet.Kernel.Read as Kernel
-import           Cardano.Wallet.Kernel.Types (AccountId (..))
 import           Cardano.Wallet.WalletLayer (CreateAddressError (..),
                      ValidateAddressError (..))
 import           Cardano.Wallet.WalletLayer.Kernel.Conv
@@ -44,7 +43,7 @@ createAddress wallet
                fromAccountId wId accIx
     fmap mkAddress $
         withExceptT CreateAddressError $ ExceptT $ liftIO $
-            Kernel.createAddress passPhrase (AccountIdHdRnd accId) wallet
+            Kernel.createAddress passPhrase accId wallet
   where
     passPhrase = maybe mempty coerce mbSpendingPassword
 

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -60,7 +60,6 @@ import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import qualified Cardano.Wallet.Kernel.PrefilterTx as Kernel
 import qualified Cardano.Wallet.Kernel.Read as Kernel
 import qualified Cardano.Wallet.Kernel.Transactions as Kernel
-import           Cardano.Wallet.Kernel.Types (AccountId (..), WalletId (..))
 import qualified Cardano.Wallet.Kernel.Wallets as Kernel
 import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..),
                      walletPassiveLayer)
@@ -84,7 +83,7 @@ data Fix = Fix {
       fixtureHdRootId  :: HdRootId
     , fixtureHdRoot    :: HdRoot
     , fixtureESK       :: EncryptedSecretKey
-    , fixtureAccountId :: AccountId
+    , fixtureAccountId :: HdAccountId
     , fixtureUtxo      :: Core.Utxo
     }
 
@@ -127,7 +126,7 @@ prepareFixtures nm initialBalance = do
         return $ Fix {
               fixtureHdRootId = newRootId
             , fixtureHdRoot = newRoot
-            , fixtureAccountId = AccountIdHdRnd newAccountId
+            , fixtureAccountId = newAccountId
             , fixtureESK = esk
             , fixtureUtxo = utxo'
             }
@@ -135,7 +134,7 @@ prepareFixtures nm initialBalance = do
     return $ \keystore aw -> do
         let pw = Kernel.walletPassive aw
         forM_ fixt $ \Fix{..} -> do
-            liftIO $ Keystore.insert (WalletIdHdRnd fixtureHdRootId) fixtureESK keystore
+            liftIO $ Keystore.insert fixtureHdRootId fixtureESK keystore
 
             let accounts    = Kernel.prefilterUtxo nm fixtureHdRootId fixtureESK fixtureUtxo
                 hdAccountId = Kernel.defaultHdAccountId fixtureHdRootId
@@ -174,7 +173,7 @@ prepareUTxoFixtures nm coins = do
         ) M.empty (mkCoin <$> coins)
     return $ \keystore aw -> do
         let pw = Kernel.walletPassive aw
-        Keystore.insert (WalletIdHdRnd newRootId) esk keystore
+        Keystore.insert newRootId esk keystore
         let accounts    = Kernel.prefilterUtxo nm newRootId esk utxo
             hdAccountId = Kernel.defaultHdAccountId newRootId
             hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
@@ -183,7 +182,7 @@ prepareUTxoFixtures nm coins = do
         return $ Fix {
             fixtureHdRootId = newRootId
           , fixtureHdRoot = newRoot
-          , fixtureAccountId = AccountIdHdRnd newAccountId
+          , fixtureAccountId = newAccountId
           , fixtureESK = esk
           , fixtureUtxo = utxo
           }
@@ -237,8 +236,7 @@ getNonFixedAddress :: WalletLayer.ActiveWalletLayer IO -> Fix -> IO Core.Address
 getNonFixedAddress layer Fix{..} = do
     let params = RequestParams (PaginationParams (Page 1) (PerPage 10))
     let filters = NoFilters
-    let (AccountIdHdRnd hdAccountId) = fixtureAccountId
-    let index = getHdAccountIx $ hdAccountId ^. hdAccountIdIx
+    let index = getHdAccountIx $ fixtureAccountId ^. hdAccountIdIx
     Right wr <- WalletLayer.getAccountAddresses (walletPassiveLayer layer)
             (Kernel.Conv.toRootId fixtureHdRootId)
             (V1.unsafeMkAccountIndex index)
@@ -250,8 +248,7 @@ getNonFixedAddress layer Fix{..} = do
 
 getAccountBalanceNow :: Kernel.PassiveWallet -> Fix -> IO Word64
 getAccountBalanceNow pw Fix{..} = do
-    let (AccountIdHdRnd hdAccountId) = fixtureAccountId
-    let index = getHdAccountIx $ hdAccountId ^. hdAccountIdIx
+    let index = getHdAccountIx $ fixtureAccountId ^. hdAccountIdIx
     db <- Kernel.getWalletSnapshot pw
     let res =
             Accounts.getAccountBalance
@@ -305,9 +302,8 @@ spec = do
                     -- get the balance before the payment
                     coinsBefore <- getAccountBalanceNow pw f
                     -- do the payment
-                    let (AccountIdHdRnd myAccountId) = fixtureAccountId
-                        src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
-                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ myAccountId ^. hdAccountIdIx)
+                    let src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
+                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ fixtureAccountId ^. hdAccountIdIx)
                         payment = V1.Payment src distr Nothing Nothing
                     Right _ <- Active.pay aw emptyPassphrase PreferGrouping SenderPaysFee payment
                     -- get the balance after the payment.
@@ -327,9 +323,8 @@ spec = do
                 withUtxosFixture @IO pm [300, 400, 500, 600, 5000000] $ \_keystore _activeLayer aw Fix{..} -> do
                     let pw = Kernel.walletPassive aw
                     -- do the payment
-                    let (AccountIdHdRnd myAccountId) = fixtureAccountId
-                        src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
-                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ myAccountId ^. hdAccountIdIx)
+                    let src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
+                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ fixtureAccountId ^. hdAccountIdIx)
                         payment = V1.Payment src distr Nothing Nothing
                     Right c <- Active.estimateFees aw PreferGrouping SenderPaysFee payment
                     -- sanity check.
@@ -342,11 +337,10 @@ spec = do
                 testMetaSTB <- pick genMeta
                 pm          <- pick arbitrary
                 Addresses.withFixture pm $ \keystore layer pwallet Addresses.Fixture{..} -> do
-                    liftIO $ Keystore.insert (WalletIdHdRnd fixtureHdRootId) fixtureESK keystore
+                    liftIO $ Keystore.insert fixtureHdRootId fixtureESK keystore
                     let (HdRootId hdRoot) = fixtureHdRootId
-                        (AccountIdHdRnd myAccountId) = fixtureAccountId
                         wId = sformat build (view fromDb hdRoot)
-                        accIdx = myAccountId ^. hdAccountIdIx . to getHdAccountIx
+                        accIdx = fixtureAccountId ^. hdAccountIdIx . to getHdAccountIx
                         hdl = (pwallet ^. Kernel.walletMeta)
                         testMeta = unSTB testMetaSTB
                     case decodeTextAddress wId of
@@ -392,11 +386,10 @@ spec = do
             monadicIO $ do
                 pm <- pick arbitrary
                 NewPayment.withFixture @IO pm (InitialADA 10000) (PayLovelace 25) $ \keystore activeLayer aw NewPayment.Fixture{..} -> do
-                    liftIO $ Keystore.insert (WalletIdHdRnd fixtureHdRootId) fixtureESK keystore
-                    let (AccountIdHdRnd hdAccountId)  = fixtureAccountId
+                    liftIO $ Keystore.insert fixtureHdRootId fixtureESK keystore
                     let (HdRootId (InDb rootAddress)) = fixtureHdRootId
                     let sourceWallet = V1.WalletId (sformat build rootAddress)
-                    let accountIndex = Kernel.Conv.toAccountId hdAccountId
+                    let accountIndex = Kernel.Conv.toAccountId fixtureAccountId
                     let destinations =
                             fmap (\(addr, coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.WalletCoin coin)
                                 ) fixturePayees
@@ -419,10 +412,10 @@ spec = do
                                 layer = walletPassiveLayer activeLayer
                                 (HdRootId hdRoot) = fixtureHdRootId
                                 wId = sformat build (view fromDb hdRoot)
-                                accIdx = Kernel.Conv.toAccountId hdAccountId
+                                accIdx = Kernel.Conv.toAccountId fixtureAccountId
                                 hdl = (pw ^. Kernel.walletMeta)
                             db <- Kernel.getWalletSnapshot pw
-                            let isPending = Kernel.currentTxIsPending db txid hdAccountId
+                            let isPending = Kernel.currentTxIsPending db txid fixtureAccountId
                             _ <- case isPending of
                                 Left _err -> expectationFailure "hdAccountId not found in Acid State from Kernel"
                                 Right False -> expectationFailure "txid not found in Acid State from Kernel"
@@ -480,8 +473,7 @@ spec = do
                 pm <- pick arbitrary
                 NewPayment.withFixture @IO pm (InitialADA 10000) (PayLovelace 100) $ \_ _ aw NewPayment.Fixture{..} -> do
                     -- we use constant fees here, to have predictable txAmount.
-                    let (AccountIdHdRnd hdAccountId) = fixtureAccountId
-                    (_tx, txMeta) <- payAux aw hdAccountId fixturePayees 200
+                    (_tx, txMeta) <- payAux aw fixtureAccountId fixturePayees 200
                     txMeta ^. txMetaAmount `shouldBe` Coin 300
 
     describe "Transactions with multiple wallets" $ do
@@ -506,9 +498,8 @@ spec = do
                 withFixture @IO pm (InitialADA 10000) $ \_ layer aw (Fixture [w1, w2] _) -> do
                     let pw = Kernel.walletPassive aw
                     address <- getFixedAddress layer w2
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     let payees = (NonEmpty.fromList [(address, Coin 100)])
-                    (_tx, txMeta) <- payAux aw hdAccountId1 payees 200
+                    (_tx, txMeta) <- payAux aw (fixtureAccountId w1) payees 200
                     txMeta ^. txMetaAmount `shouldBe` Coin 300
                     txMeta ^. txMetaIsOutgoing `shouldBe` True
                     txMeta ^. txMetaIsLocal `shouldBe` False
@@ -523,9 +514,8 @@ spec = do
                 pm <- pick arbitrary
                 withFixture @IO pm (InitialADA 10000) $ \_ layer aw (Fixture [w1, w2] _) -> do
                     address <- getNonFixedAddress layer w2
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     let payees = (NonEmpty.fromList [(address, Coin 100)])
-                    (_tx, txMeta) <- payAux aw hdAccountId1 payees 200
+                    (_tx, txMeta) <- payAux aw (fixtureAccountId w1) payees 200
                     txMeta ^. txMetaAmount `shouldBe` Coin 300
 
         prop "payment to different wallet changes the balance the same as txAmount" $ withMaxSuccess 5 $
@@ -536,10 +526,9 @@ spec = do
                     -- get the balance before the payment
                     coinsBefore <- getAccountBalanceNow pw w1
                     -- do the payment
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     address <- getFixedAddress layer w2
                     let payees = (NonEmpty.fromList [(address, Coin 100)])
-                    (_tx, txMeta) <- payAux aw hdAccountId1 payees 200
+                    (_tx, txMeta) <- payAux aw (fixtureAccountId w1) payees 200
                     txMeta ^. txMetaAmount `shouldBe` Coin 300
                     -- get the balance after the payment
                     coinsAfter <- getAccountBalanceNow pw w1
@@ -550,13 +539,12 @@ spec = do
                 pm <- pick arbitrary
                 withFixture @IO pm (InitialADA 10000) $ \_ layer aw (Fixture [w1, w2] _) -> do
                     let pw = Kernel.walletPassive aw
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     -- get the balance before the payment
                     coinsBefore <- getAccountBalanceNow pw w1
                     -- do the payment
                     address <- getNonFixedAddress layer w2
                     let payees = (NonEmpty.fromList [(address, Coin 100)])
-                    (_tx, txMeta) <- payAux aw hdAccountId1 payees 200
+                    (_tx, txMeta) <- payAux aw (fixtureAccountId w1) payees 200
                     txMeta ^. txMetaAmount `shouldBe` Coin 300
                     -- get the balance after the payment
                     coinsAfter <- getAccountBalanceNow pw w1
@@ -570,15 +558,14 @@ spec = do
                     -- get the balance before the payment
                     coinsBefore <- getAccountBalanceNow pw w1
                     -- do the payment
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     address1 <- getFixedAddress layer w2
                     address2 <- getNonFixedAddress layer w2
                     let payees1 = (NonEmpty.fromList [(address1, Coin 100)])
-                    (_, txMeta1) <- payAux aw hdAccountId1 payees1 200
+                    (_, txMeta1) <- payAux aw (fixtureAccountId w1) payees1 200
                     txMeta1 ^. txMetaAmount `shouldBe` Coin 300
                     -- do the second payment
                     let payees2 = (NonEmpty.fromList [(address2, Coin 400)])
-                    (_, txMeta2) <- payAux aw hdAccountId1 payees2 800
+                    (_, txMeta2) <- payAux aw (fixtureAccountId w1) payees2 800
                     txMeta2 ^. txMetaAmount `shouldBe` Coin 1200
                     -- get the balance after the payment
                     coinsAfter <- getAccountBalanceNow pw w1
@@ -594,9 +581,8 @@ spec = do
                     coinsBefore <- getAccountBalanceNow pw w1
                     -- do the payment
                     address <- getFixedAddress layer w1
-                    let (AccountIdHdRnd hdAccountId1) = fixtureAccountId w1
                     let payees = (NonEmpty.fromList [(address, Coin 100)])
-                    (_, txMeta) <- payAux aw hdAccountId1 payees 200
+                    (_, txMeta) <- payAux aw (fixtureAccountId w1) payees 200
                     -- this is 200 because the outputs is at the same wallet.
                     txMeta ^. txMetaAmount `shouldBe` Coin 200
                     txMeta ^. txMetaIsOutgoing `shouldBe` True

--- a/test/unit/Test/Spec/Keystore.hs
+++ b/test/unit/Test/Spec/Keystore.hs
@@ -19,10 +19,9 @@ import           Test.QuickCheck.Monadic (forAllM, monadicIO, pick, run)
 import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, hash, safeKeyGen)
 
-import           Cardano.Wallet.Kernel.DB.HdWallet (eskToHdRootId)
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.Keystore (DeletePolicy (..), Keystore)
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 
 import           Util.Buildable (ShowThroughBuild (..))
 
@@ -34,15 +33,15 @@ withKeystore :: (Keystore -> IO a) -> IO a
 withKeystore = Keystore.bracketTestKeystore
 
 genKeypair :: NetworkMagic
-           -> Gen ( ShowThroughBuild WalletId
+           -> Gen ( ShowThroughBuild HdRootId
                   , ShowThroughBuild EncryptedSecretKey
                   )
 genKeypair nm = do
     (_, esk) <- arbitrary >>= safeKeyGen
-    return $ bimap STB STB (WalletIdHdRnd . eskToHdRootId nm $ esk, esk)
+    return $ bimap STB STB (eskToHdRootId nm $ esk, esk)
 
 genKeys :: NetworkMagic
-        -> Gen ( ShowThroughBuild WalletId
+        -> Gen ( ShowThroughBuild HdRootId
                , ShowThroughBuild EncryptedSecretKey
                , ShowThroughBuild EncryptedSecretKey
                )

--- a/test/unit/Test/Spec/Wallets.hs
+++ b/test/unit/Test/Spec/Wallets.hs
@@ -32,7 +32,6 @@ import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import qualified Cardano.Wallet.Kernel.Internal as Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
-import           Cardano.Wallet.Kernel.Types (WalletId (..))
 import           Cardano.Wallet.Kernel.Wallets (CreateWalletError (..))
 import qualified Cardano.Wallet.Kernel.Wallets as Kernel
 import qualified Cardano.Wallet.WalletLayer as WalletLayer
@@ -173,7 +172,7 @@ spec = describe "Wallets" $ do
                                  Right hdRoot -> do
                                      --  Check that the key is in the keystore
                                      let nm  = makeNetworkMagic pm
-                                         wid = WalletIdHdRnd (hdRoot ^. hdRootId)
+                                         wid = hdRoot ^. hdRootId
                                      mbEsk <- Keystore.lookup nm wid (wallet ^. Internal.walletKeystore)
                                      mbEsk `shouldSatisfy` isJust
 
@@ -282,7 +281,7 @@ spec = describe "Wallets" $ do
                     withNewWalletFixture pm $ \ks _ wallet Fixture{..} -> do
                         liftIO $ do
                             let nm  = makeNetworkMagic pm
-                                wId = WalletIdHdRnd fixtureHdRootId
+                                wId = fixtureHdRootId
 
                             mbKey <- Keystore.lookup nm wId ks
                             mbKey `shouldSatisfy` isJust
@@ -333,7 +332,7 @@ spec = describe "Wallets" $ do
                     pm     <- pick arbitrary
                     withNewWalletFixture pm $ \ keystore _ wallet Fixture{..} -> do
                         let nm  = makeNetworkMagic pm
-                            wid = WalletIdHdRnd fixtureHdRootId
+                            wid = fixtureHdRootId
                         oldKey <- Keystore.lookup nm wid keystore
                         let V1.WalletPassPhrase corePassword = fixtureSpendingPassword
                         res <- Kernel.updatePassword wallet

--- a/test/unit/Wallet/Inductive/Cardano.hs
+++ b/test/unit/Wallet/Inductive/Cardano.hs
@@ -251,7 +251,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
              Left e -> createWalletErr (STB e)
              Right hdRoot -> do
                  let keystore = passiveWallet ^. Internal.walletKeystore
-                 liftIO $ Keystore.insert (WalletIdHdRnd $ hdRoot ^. HD.hdRootId) esk keystore
+                 liftIO $ Keystore.insert (hdRoot ^. HD.hdRootId) esk keystore
                  checkWalletAccountState ctxt accountIds
 
         where


### PR DESCRIPTION

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#34</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed `WalletId` and `AccountId` "Kernel Types" in favor of their `Hd` equivalent. 


# Comments

<!-- Additional comments or screenshots to attach if any -->

These were introduced in prevision of future evolution. However, we now know that we want to keep the same Hd representation for sequential and random wallets. As such, those types only add one extra unnecessary level of indirection.

This is the first PR of a serie about redesigning the prefiltering code. I'll try to proceed with incremental changes and clean up like this before submitting the actual prefiltering redesign such that the intent is made clearer at that time.


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
