### PR TITLE
Favor 'Monoid' and 'Semigroup' instances for BlockMeta

### DIFF
--- a/src/Cardano/Wallet/Kernel/DB/Spec.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Spec.hs
@@ -140,7 +140,7 @@ initCheckpoint utxo = Checkpoint {
                                         Core.utxoBalance utxo
     , _checkpointPending     = Pending.empty
     , _checkpointForeign     = Pending.empty
-    , _checkpointBlockMeta   = emptyBlockMeta
+    , _checkpointBlockMeta   = mempty
     , _checkpointContext     = Strict.Nothing
     }
 
@@ -175,7 +175,7 @@ makeLenses ''PartialCheckpoint
 -- for all blocks /after/ the initial partial checkpoint, and we have (complete)
 -- block metadata for all historical checkpoints that we recover, but this is
 -- only checkpoint for which we have no block metadata at all. Therefore we set
--- the block metadata to 'emptyBlockMeta'. Then during restoration when we are
+-- the block metadata to 'mempty'. Then during restoration when we are
 -- recovering  historical checkpoints, we don't stop until the historical
 -- checkpoints /overlap/ one block with the partial checkpoints, so that the
 -- block metadata of this initial partial checkpoint is not used.
@@ -225,13 +225,10 @@ toFullCheckpoint prevBlockMeta PartialCheckpoint{..} = Checkpoint {
       _checkpointUtxo        =             _pcheckpointUtxo
     , _checkpointUtxoBalance =             _pcheckpointUtxoBalance
     , _checkpointPending     =             _pcheckpointPending
-    , _checkpointBlockMeta   =    withPrev _pcheckpointBlockMeta
+    , _checkpointBlockMeta   = prevBlockMeta <> localBlockMeta _pcheckpointBlockMeta
     , _checkpointContext     = Strict.Just _pcheckpointContext
     , _checkpointForeign     =             _pcheckpointForeign
     }
-  where
-    withPrev :: LocalBlockMeta -> BlockMeta
-    withPrev = appendBlockMeta prevBlockMeta
 
 {-------------------------------------------------------------------------------
   Checkpoints Wrapper

--- a/src/Cardano/Wallet/Kernel/PrefilterTx.hs
+++ b/src/Cardano/Wallet/Kernel/PrefilterTx.hs
@@ -86,7 +86,7 @@ emptyPrefilteredBlock context = PrefilteredBlock {
     , pfbForeignInputs  = Set.empty
     , pfbOutputs        = Map.empty
     , pfbAddrs          = []
-    , pfbMeta           = emptyLocalBlockMeta
+    , pfbMeta           = mempty
     , pfbContext        = context
     }
 


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#34</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed custom functions `append***Meta` and `empty***Meta` in favor of their Monoid and Semigroup equivalents.

# Comments

<!-- Additional comments or screenshots to attach if any -->

This will ultimately help with redesigning the prefiltering code as it gives a us a common interface to combine things with standard haskell algebraic data-structures. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
