### PR TITLE
Fix order of evaluation in integration DSL assertion

### DIFF
--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -459,7 +459,7 @@ expectWalletError
     -> m ()
 expectWalletError e' = \case
     Right a -> wantedErrorButSuccess a
-    Left e  -> (ClientWalletError e') `shouldBe` e
+    Left e  -> e `shouldBe` (ClientWalletError e')
 
 
 -- | Verifies that the response is errored from a failed JSON validation


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
<p align="right">#34</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have inverted the arguments for `shouldBe` when asserting errors, such that the error message better reflect the actual assertion.

# Comments

<!-- Additional comments or screenshots to attach if any -->

when failed, this looked like:

```
  expected: ClientWalletError AddressNotFound
  but got: ClientWalletError (NotEnoughMoney ErrCannotCoverFee)
```

The first argument passed to `shouldBe` should be what we got, and the second what we actually expected.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
