### PR TITLE
spendingPasswordLastUpdate updated correctly if password was removed.

### DIFF
--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -328,7 +328,7 @@ createWalletHdRnd pw hasSpendingPassword defaultCardanoAddress name assuranceLev
         hdSpendingPassword :: InDb Timestamp -> HD.HasSpendingPassword
         hdSpendingPassword created =
             if hasSpendingPassword then HD.HasSpendingPassword created
-                                   else HD.NoSpendingPassword
+                                   else HD.NoSpendingPassword created
 
 -- | Creates a default 'HdAddress' at a fixed derivation path. This is
 -- useful for tests, but otherwise you may want to use 'defaultHdAddressWith'.
@@ -473,7 +473,7 @@ updatePassword pw hdRootId oldPassword newPassword = do
                                -- here and update 'hasSpendingPassword' on 'HdRoot' accordingly.
                                let hasSpendingPassword =
                                        if newPassword == emptyPassphrase
-                                       then HD.NoSpendingPassword
+                                       then HD.NoSpendingPassword lastUpdateNow
                                        else HD.HasSpendingPassword lastUpdateNow
 
                                res <- update' (pw ^. wallets)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -174,15 +174,14 @@ toWallet db hdRoot = V1.Wallet {
     , walType                       = V1.WalletRegular
     }
   where
-    (hasSpendingPassword, mbLastUpdate) =
+    (hasSpendingPassword, lastUpdate) =
         case hdRoot ^. HD.hdRootHasPassword of
-             HD.NoSpendingPassword     -> (False, Nothing)
-             HD.HasSpendingPassword lu -> (True, Just (lu ^. fromDb))
+             HD.NoSpendingPassword lr  -> (False, lr ^. fromDb)
+             HD.HasSpendingPassword lu -> (True, lu ^. fromDb)
     -- In case the wallet has no spending password, its last update
     -- matches this wallet creation time.
     rootId           = hdRoot ^. HD.hdRootId
     createdAt        = hdRoot ^. HD.hdRootCreatedAt . fromDb
-    lastUpdate       = fromMaybe createdAt mbLastUpdate
     walletId         = sformat build . _fromDb . HD.getHdRootId $ rootId
     v1AssuranceLevel = toAssuranceLevel $ hdRoot ^. HD.hdRootAssurance
 

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -17,7 +17,7 @@ import           Test.QuickCheck (arbitrary, choose, elements, withMaxSuccess,
                      (===))
 import           Test.QuickCheck.Monadic (PropertyM, monadicIO, pick)
 
-import           Pos.Core (Address, addrRoot)
+import           Pos.Core (Address, addrRoot, getCurrentTimestamp)
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, emptyPassphrase,
                      firstHardened, safeDeterministicKeyGen)
@@ -75,9 +75,10 @@ prepareFixtures :: NetworkMagic -> Fixture.GenPassiveWalletFixture Fixture
 prepareFixtures nm = do
     let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
     let newRootId = eskToHdRootId nm esk
+    now <- getCurrentTimestamp
     newRoot <- initHdRoot <$> pure newRootId
                           <*> pure (WalletName "A wallet")
-                          <*> pure NoSpendingPassword
+                          <*> pure (NoSpendingPassword $ InDb now)
                           <*> pure AssuranceLevelNormal
                           <*> (InDb <$> pick arbitrary)
     newAccountId <- HdAccountId newRootId <$> deriveIndex (pick . choose) HdAccountIx HardDerivation

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -26,7 +26,7 @@ import           Pos.Chain.Txp (TxOut (..), TxOutAux (..))
 import qualified Pos.Chain.Txp as Core
 import           Pos.Core as Core
 import           Pos.Core (Coin (..), IsBootstrapEraAddr (..),
-                     deriveLvl2KeyPair, mkCoin)
+                     deriveLvl2KeyPair, getCurrentTimestamp, mkCoin)
 import           Pos.Core.NetworkMagic (NetworkMagic (..), makeNetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic,
                      ShouldCheckPassphrase (..), emptyPassphrase,
@@ -100,9 +100,10 @@ prepareFixtures nm initialBalance = do
     fixt <- forM [0x11, 0x22] $ \b -> do
         let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 b) mempty
         let newRootId = eskToHdRootId nm esk
+        now <- getCurrentTimestamp
         newRoot <- initHdRoot <$> pure newRootId
                             <*> pure (WalletName "A wallet")
-                            <*> pure NoSpendingPassword
+                            <*> pure (NoSpendingPassword $ InDb now)
                             <*> pure AssuranceLevelNormal
                             <*> (InDb <$> pick arbitrary)
         newAccountId <- HdAccountId newRootId <$> deriveIndex (pick . choose) HdAccountIx HardDerivation

--- a/test/unit/Test/Spec/NewPayment.hs
+++ b/test/unit/Test/Spec/NewPayment.hs
@@ -25,7 +25,7 @@ import           Formatting (build, formatToString, sformat)
 
 import           Pos.Chain.Txp (TxOut (..), TxOutAux (..))
 import           Pos.Core (Address, Coin (..), IsBootstrapEraAddr (..),
-                     deriveLvl2KeyPair, mkCoin)
+                     deriveLvl2KeyPair, getCurrentTimestamp, mkCoin)
 import           Pos.Core.NetworkMagic (NetworkMagic (..), makeNetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic,
                      ShouldCheckPassphrase (..), emptyPassphrase,
@@ -88,9 +88,10 @@ prepareFixtures :: NetworkMagic
 prepareFixtures nm initialBalance toPay = do
     let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
     let newRootId = eskToHdRootId nm esk
+    now <- getCurrentTimestamp
     newRoot <- initHdRoot <$> pure newRootId
                           <*> pure (WalletName "A wallet")
-                          <*> pure NoSpendingPassword
+                          <*> pure (NoSpendingPassword $ InDb now)
                           <*> pure AssuranceLevelNormal
                           <*> (InDb <$> pick arbitrary)
     newAccountId <- HdAccountId newRootId <$> deriveIndex (pick . choose) HdAccountIx HardDerivation

--- a/test/unit/Test/Spec/Wallets.hs
+++ b/test/unit/Test/Spec/Wallets.hs
@@ -359,7 +359,7 @@ spec = describe "Wallets" $ do
                                                      newPwd
                         let passphraseIsEmpty = newPwd == emptyPassphrase
                         let satisfied = \case
-                                        HD.NoSpendingPassword    -> passphraseIsEmpty
+                                        HD.NoSpendingPassword _  -> passphraseIsEmpty
                                         HD.HasSpendingPassword _ -> not passphraseIsEmpty
                         case res of
                              Left e -> fail (show e)


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#166</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Type `HasSpendingPassword` was extended: `NoSpendingPassword` constructor has a timestamp. 
- [ ] `acid-state` migrations for `HasSpendingPassword` and `HdRoot`.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
