### PR TITLE
Provide reason when swagger json validation fails

### DIFF
--- a/test/unit/API/SwaggerSpec.hs
+++ b/test/unit/API/SwaggerSpec.hs
@@ -29,7 +29,7 @@ import           Servant.JsendCompliance (checkJsendCompliance)
 import           Data.Aeson (ToJSON (..))
 import           Servant.Swagger.Internal.Test (props)
 import           Servant.Swagger.Internal.TypeLevel (BodyTypes, Every, TMap)
-import           Test.QuickCheck (Arbitrary, arbitrary, property)
+import           Test.QuickCheck (Arbitrary, arbitrary, property, (===))
 
 -- Syntethic instances and orphans to be able to use `validateEveryToJSON`.
 -- In the future, hopefully, we will never need these.
@@ -87,5 +87,5 @@ validateEveryToJSON'
     -> Spec
 validateEveryToJSON' _ = props
   (Proxy :: Proxy [ToJSON, ToSchema])
-  (property . null . validateToJSON)
+  (property . (=== []) . validateToJSON)
   (Proxy :: Proxy (BodyTypes ValidJSON api))


### PR DESCRIPTION
#205 

# Overview

When there is a mismatch between `ToSchema` and `ToJSON`, `validateToJSON` returns a list of failure reasons. These are not currently printed in the property test testing this. Simple solution: `(=== [])`

```
       Falsifiable (after 2 tests):
         APIResponse {wrData = NodeSettings {setSlotId = SlotId {siEpoch = EpochIndex {getEpochIndex = 1331246665611}, siSlot = UnsafeLocalSlotIndex {getSlotIndex = 71}}, setSlotDuration = SlotDuration (MeasuredIn 73), setSlotCount = SlotCount {getSlotCount = 59}, setSoftwareInfo = :25, setProjectVersion = Version {versionBranch = [0,1,7], versionTags = []}, setGitRevision = "0e1c9322a", setMaxTxSize = MaxTxSize (MeasuredIn (-9)), setFeePolicy = TxFeePolicyTxSizeLinear (TxSizeLinear (Coeff -17.885579848) (Coeff -263.217127901)), setSecurityParameter = SecurityParameter 8}, wrStatus = SuccessStatus, wrMeta = Metadata {metaPagination = PaginationMetadata {metaTotalPages = 10, metaPage = Page 7, metaPerPage = PerPage 44, metaTotalEntries = 7}}}
         ["value -9.0 falls below minimum (should be >=0.0)"] /= []
```

With this pr we get the `["value -9.0 falls below minimum (should be >=0.0)"] /= []` part.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->