### PR TITLE
Remove 'isChangeAddress' metadata

### DIFF
--- a/src/Cardano/Wallet/API/V1/Types.hs
+++ b/src/Cardano/Wallet/API/V1/Types.hs
@@ -69,7 +69,6 @@ module Cardano.Wallet.API.V1.Types (
   , AddressLevel
   , addressLevelToWord32
   , word32ToAddressLevel
-  , IsChangeAddress (..)
   -- * Payments
   , Payment (..)
   , PaymentSource (..)
@@ -1058,10 +1057,9 @@ instance Buildable WAddressMeta where
 
 -- | Summary about single address.
 data WalletAddress = WalletAddress
-    { addrId            :: !WalAddress
-    , addrUsed          :: !Bool
-    , addrChangeAddress :: !Bool
-    , addrOwnership     :: !AddressOwnership
+    { addrId        :: !WalAddress
+    , addrUsed      :: !Bool
+    , addrOwnership :: !AddressOwnership
     } deriving (Show, Eq, Generic, Ord)
 
 deriveJSON Aeson.defaultOptions ''WalletAddress
@@ -1071,13 +1069,11 @@ instance ToSchema WalletAddress where
         genericSchemaDroppingPrefix "addr" (\(--^) props -> props
             & ("id"            --^ "Actual address.")
             & ("used"          --^ "True if this address has been used.")
-            & ("changeAddress" --^ "True if this address stores change from a previous transaction.")
             & ("ownership"     --^ "'isOurs' if this address is recognised as ours, 'ambiguousOwnership' if the node doesn't have information to make a unambiguous statement.")
         )
 
 instance Arbitrary WalletAddress where
     arbitrary = WalletAddress <$> arbitrary
-                              <*> arbitrary
                               <*> arbitrary
                               <*> arbitrary
 
@@ -1306,11 +1302,9 @@ instance BuildableSafeGen WalletAddress where
     buildSafeGen sl WalletAddress{..} = bprint ("{"
         %" id="%buildSafe sl
         %" used="%build
-        %" changeAddress="%build
         %" }")
         addrId
         addrUsed
-        addrChangeAddress
 
 instance Buildable [WalletAddress] where
     build = bprint listJson
@@ -1400,8 +1394,6 @@ instance ToJSON AddressLevel where
 
 instance FromJSON AddressLevel where
     parseJSON = fmap word32ToAddressLevel . parseJSON
-
-newtype IsChangeAddress = IsChangeAddress Bool deriving (Show, Eq)
 
 -- | A type incapsulating a password update request.
 data PasswordUpdate = PasswordUpdate {

--- a/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
+++ b/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
@@ -12,7 +12,6 @@ module Cardano.Wallet.Kernel.DB.BlockMeta (
     -- * Local block metadata
   , LocalBlockMeta(..)
     -- ** Lenses
-  , addressMetaIsChange
   , addressMetaIsUsed
   , blockMetaAddressMeta
   , blockMetaSlotId
@@ -42,19 +41,13 @@ import           Cardano.Wallet.Kernel.DB.InDb
 data AddressMeta = AddressMeta {
       -- | Whether or not an Address has been 'used'
       _addressMetaIsUsed   :: Bool
-      -- | Whether or not this is a 'change' Address
-    , _addressMetaIsChange :: Bool
     } deriving Eq
 
 instance Semigroup AddressMeta where
-  a <> b = mergeAddrMeta a b
-    where
-      mergeAddrMeta :: AddressMeta -> AddressMeta -> AddressMeta
-      mergeAddrMeta (AddressMeta used change) (AddressMeta used' change')
-          = AddressMeta (used || used') (change `xor` change')
+    (AddressMeta used) <> (AddressMeta used') = AddressMeta (used || used')
 
 instance Monoid AddressMeta where
-  mempty  = AddressMeta False False
+  mempty  = AddressMeta False
   mappend = (<>)
 
 makeLenses ''AddressMeta
@@ -117,11 +110,9 @@ instance Buildable AddressMeta where
     build AddressMeta{..} = bprint
         ( "AddressMeta"
         % "{ isUsed:   " % build
-        % ", isChange: " % build
         % "}"
         )
         _addressMetaIsUsed
-        _addressMetaIsChange
 
 instance Buildable BlockMeta where
     build BlockMeta{..} = bprint

--- a/src/Cardano/Wallet/Kernel/DB/Spec.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Spec.hs
@@ -201,7 +201,6 @@ utxoToAddressMeta utxo =
     where
       usedMeta = AddressMeta {
           _addressMetaIsUsed = True
-        , _addressMetaIsChange = False
       }
 
 -- | A full check point with a non-Nothing context can be " downcast " to a

--- a/src/Cardano/Wallet/Kernel/PrefilterTx.hs
+++ b/src/Cardano/Wallet/Kernel/PrefilterTx.hs
@@ -334,30 +334,15 @@ mkBlockMeta slotId addrs_ txIds = LocalBlockMeta BlockMeta{..}
 --   hence that there are at least one or more summaries passed to this function
 --   for a given address.
 mkAddressMeta :: NE.NonEmpty AddressSummary -> AddressMeta
-mkAddressMeta addrs
-    = AddressMeta isUsed isChange
+mkAddressMeta _
+    = AddressMeta isUsed
     where
-        occurs = NE.length addrs
-
         -- An address is considered "used" if
         -- (1) it is "our" address: we are only dealing with prefiltered transactions
         --     here and can at this stage assume that the address is indeed "ours".
         -- (2) the transaction is confirmed: we are dealing here with transactions that
         --     appear in a block and can assume that they are confirmed.
         isUsed = True
-
-        -- An address is considered "change" if
-        -- (1) it is "our" address: as with `isUsed` above, we can assume the address is "ours"
-        -- (2) the address occurs in exactly one transaction in this block
-        -- (3) for the (single) transaction in which this address appears, the
-        --     outputs must not all be to "our" addresses (the transaction must have
-        --     an output to at least one address that is not "ours")
-        -- (4) all the inputs of the transaction in which this address appears
-        --     must be "ours"
-        isChange = (occurs == 1)                    -- (2)
-                    && addrSummaryOnlyOurInps       -- (3)
-                    && not addrSummaryOnlyOurOuts   -- (4)
-            where AddressSummary{..} = NE.head addrs
 
 -- | Index the list of address summaries by Address.
 --   NOTE: Since there will be at least one AddressSummary per Address,

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
@@ -48,9 +48,9 @@ createAddress wallet
     passPhrase = maybe mempty coerce mbSpendingPassword
 
     -- | Creates a new 'WalletAddress'. As this is a brand new, fresh Address,
-    -- it's fine to have 'False' for both 'isUsed' and 'isChange'.
+    -- it's fine to have 'False' for 'isUsed'
     mkAddress :: Address -> WalletAddress
-    mkAddress addr = WalletAddress (V1.WalAddress addr) False False V1.AddressIsOurs
+    mkAddress addr = WalletAddress (V1.WalAddress addr) False V1.AddressIsOurs
 
 
 
@@ -182,6 +182,5 @@ validateAddress rawText db = runExcept $ do
         return V1.WalletAddress {
             addrId            = V1.WalAddress cardanoAddress
           , addrUsed          = False
-          , addrChangeAddress = False
           , addrOwnership     = V1.AddressAmbiguousOwnership
           }

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -48,8 +48,7 @@ import           Cardano.Wallet.API.Types.UnitOfMeasure
 import qualified Cardano.Wallet.API.V1.Types as V1
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
                      (InputGrouping (..))
-import           Cardano.Wallet.Kernel.DB.BlockMeta (addressMetaIsChange,
-                     addressMetaIsUsed)
+import           Cardano.Wallet.Kernel.DB.BlockMeta (addressMetaIsUsed)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
 import           Cardano.Wallet.Kernel.DB.Spec (cpAddressMeta)
@@ -194,7 +193,6 @@ toAddress :: HD.HdAccount -> HD.HdAddress -> V1.WalletAddress
 toAddress acc hdAddress =
     V1.WalletAddress (V1.WalAddress cardanoAddress)
                      (addressMeta ^. addressMetaIsUsed)
-                     (addressMeta ^. addressMetaIsChange)
                      addressOwnership
   where
     cardanoAddress   = hdAddress ^. HD.hdAddressAddress . fromDb

--- a/test/unit/Arbitrary.hs
+++ b/test/unit/Arbitrary.hs
@@ -70,7 +70,7 @@ instance Arbitrary LocalBlockMeta where
         pure $ LocalBlockMeta bm
 
 instance Arbitrary AddressMeta where
-    arbitrary = AddressMeta <$> arbitrary <*> arbitrary
+    arbitrary = AddressMeta <$> arbitrary
 
 instance Arbitrary Pending where
     arbitrary = do

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -552,7 +552,7 @@ spec = describe "Addresses" $ do
                              Left err -> fail $ "Got different error than expected: " <> show err
                              Right _ -> fail "I was expecting a failure, but it didn't happen."
 
-            prop "returns not used/not change for an address which is not ours" $ withMaxSuccess 5 $ do
+            prop "returns not used for an address which is not ours" $ withMaxSuccess 5 $ do
                 monadicIO $ do
                     (randomAddr :: Address) <- pick arbitrary
                     pm                      <- pick arbitrary
@@ -560,7 +560,6 @@ spec = describe "Addresses" $ do
                         expected = V1.WalletAddress {
                             addrId            = V1.WalAddress randomAddr
                           , addrUsed          = False
-                          , addrChangeAddress = False
                           , addrOwnership     = V1.AddressAmbiguousOwnership
                           }
                     withAddressFixtures pm 1 $ \_ layer _ _ -> do

--- a/test/unit/Test/Spec/BlockMetaScenarios.hs
+++ b/test/unit/Test/Spec/BlockMetaScenarios.hs
@@ -186,7 +186,7 @@ blockMetaScenarioB genVals@GenesisValues{..} =
     _blockMetaSlotId' = Map.singleton (hash t0) slot1
     --    * we expect the address to be recognised as a 'change' address in the metadata
     _blockMetaAddressMeta'
-        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = True})
+        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True })
 
 -- | Scenario C
 -- Two confirmed payments from P0 to P1, using `change` addresses P0 and P0b respectively
@@ -215,8 +215,8 @@ blockMetaScenarioC genVals@GenesisValues{..} =
     --    * we expect both addresses to be recognised as 'change' addresses in the metadata
     --      (since each address occur in exactly one confirmed transaction, and all the other requirements are met)
     _blockMetaAddressMeta'
-        = Map.fromList [  (p0,  (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = True}))
-                        , (p0b, (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = True}))]
+        = Map.fromList [  (p0,  (AddressMeta {_addressMetaIsUsed = True}))
+                        , (p0b, (AddressMeta {_addressMetaIsUsed = True}))]
 
 -- | Scenario D
 -- ScenarioC + Rollback
@@ -247,7 +247,7 @@ blockMetaScenarioD genVals@GenesisValues{..} =
     _blockMetaSlotId' = Map.singleton (hash t0) slot1
     --    * we expect the first address to still be recognised as a 'change' address in the metadata
     _blockMetaAddressMeta'
-        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = True})
+        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True})
 
 -- | Scenario E
 -- Two confirmed payments from P0 to P1, both using the same `change` address for P0
@@ -277,7 +277,7 @@ blockMetaScenarioE genVals@GenesisValues{..} =
     --    * we expect the address to no longer be recognised as a 'change' address in the metadata
     --      (because a `change` address must occur in exactly one confirmed transaction)
     _blockMetaAddressMeta'
-        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = False})
+        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True})
 
 -- | Scenario F
 -- ScenarioE + Rollback
@@ -309,7 +309,7 @@ blockMetaScenarioF genVals@GenesisValues{..} =
     --    * we expect the address to again be recognised as a 'change' address in the metadata
     --      (the rollback leads to the `change` address occuring in exactly one confirmed transaction again, as in ScenarioE)
     _blockMetaAddressMeta'
-        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = True})
+        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True})
 
 -- | Scenario G
 -- A payment from P1 to P0's single address.
@@ -336,7 +336,7 @@ blockMetaScenarioG genVals@GenesisValues{..} =
     _blockMetaSlotId' = Map.singleton (hash t0) slot1
     -- For `t0` the inputs are not all "ours" and hence `isChange` is False
     _blockMetaAddressMeta'
-        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = False})
+        = Map.singleton p0 (AddressMeta {_addressMetaIsUsed = True})
 
 -- | Scenario G
 -- A confirmed payment from P0 to a single other P0 address
@@ -365,6 +365,6 @@ blockMetaScenarioH genVals@GenesisValues{..} =
     --    * we expect none of the addresses to be recognised as 'change'
     --      (since all the transaction outputs are to addresses that are _all_ "ours")
     _blockMetaAddressMeta'
-        = Map.fromList [  (p0,  (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = False}))
-                        , (p0b, (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = False}))
-                        , (p0c, (AddressMeta {_addressMetaIsUsed = True, _addressMetaIsChange = False}))]
+        = Map.fromList [  (p0,  (AddressMeta {_addressMetaIsUsed = True}))
+                        , (p0b, (AddressMeta {_addressMetaIsUsed = True}))
+                        , (p0c, (AddressMeta {_addressMetaIsUsed = True}))]


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#34</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have remove 'isChangeAddress' from the address metadata

# Comments

<!-- Additional comments or screenshots to attach if any -->

The rational behind this change is two-fold.

1/ This is not a feature actually used. It has landed in the new
data-layer because it was present in the legacy one. Deadalus don't use
it and exchanges don't (to the best of our knowledge; currently running
a survey to double-check this information).

2/ The computed information is actually wrong. The definition of change
address as it was formalized in the wallet specification paper doesn't
account for inter-wallets transactions (since the concept of
multi-accounts doesn't even exist in the wallet specification). However,
following the existing rule, an address actually used as changed when
making a transaction between two owned accounts wouldn't be recognized
as such.

Rather than trying to fix this, we'll just remove it from the backend
and reconsider the question later if and when it comes back on the
table.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
