### PR TITLE
HdAddress type hierarchy for EOS-wallets.

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -199,6 +199,7 @@ library
       Cardano.Wallet.Kernel.DB.Compression
       Cardano.Wallet.Kernel.DB.EosHdWallet
       Cardano.Wallet.Kernel.DB.EosHdWallet.Create
+      Cardano.Wallet.Kernel.DB.EosHdWallet.Read
       Cardano.Wallet.Kernel.DB.HdWallet
       Cardano.Wallet.Kernel.DB.HdWallet.Create
       Cardano.Wallet.Kernel.DB.HdWallet.Delete

--- a/src/Cardano/Wallet/Kernel/DB/EosHdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/EosHdWallet.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Kernel.DB.EosHdWallet (
     -- ** Lenses
   , eosHdWalletsRoots
   , eosHdWalletsAccounts
+  , eosHdWalletsAddresses
   , eosHdRootId
   , eosHdRootName
   , eosHdRootAssurance
@@ -78,12 +79,17 @@ data EosHdAccount = EosHdAccount {
 
 -- | All wallets and accounts in the EOS HD wallets
 data EosHdWallets = EosHdWallets {
-    _eosHdWalletsRoots    :: !(IxSet EosHdRoot)
-  , _eosHdWalletsAccounts :: !(IxSet EosHdAccount)
+    _eosHdWalletsRoots     :: !(IxSet EosHdRoot)
+  , _eosHdWalletsAccounts  :: !(IxSet EosHdAccount)
+  -- | Currently we use existing 'Hdaddress'-hierarchy
+  -- (see 'Cardano.Wallet.Kernel.DB.HdWallet' module) to
+  -- store addresses for EOS-wallet, because technically they
+  -- are the same addresses as for FOS-wallet.
+  , _eosHdWalletsAddresses :: !(IxSet (Indexed HdAddress))
   }
 
 initEosHdWallets :: EosHdWallets
-initEosHdWallets = EosHdWallets IxSet.empty IxSet.empty
+initEosHdWallets = EosHdWallets IxSet.empty IxSet.empty IxSet.empty
 
 {-------------------------------------------------------------------------------
   Template Haskell splices

--- a/src/Cardano/Wallet/Kernel/DB/EosHdWallet/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/EosHdWallet/Read.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | READ queries on the EOS HD wallet
+--
+-- NOTE: These are pure functions, which are intended to work on a snapshot
+-- of the database. They are intended to support the V1 wallet API.
+module Cardano.Wallet.Kernel.DB.EosHdWallet.Read (
+  -- | Summarize
+  addressesByAccountId
+  ) where
+
+import           Universum
+
+import           Cardano.Wallet.Kernel.DB.EosHdWallet (EosHdWallets,
+                     eosHdWalletsAddresses)
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId, HdAddress)
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
+import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed (..), IxSet)
+import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
+
+-- | All addresses in the given account
+--
+-- NOTE: Does not check that the account exists.
+addressesByAccountId :: HdAccountId -> Query' e EosHdWallets (IxSet (Indexed HdAddress))
+addressesByAccountId accId =
+    asks $ IxSet.getEQ accId . view eosHdWalletsAddresses


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#32</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `EosHdWallets` uses the field with the same type hierarchy for storing addresses for EOS-wallets.
- [x] Function `createEosHdAddress` allows to store new address (that will be derived from account's public key)
- [x] Function `addressesByAccountId` allows to get all addresses in account to get the next (sequential) address index.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

After this PR will be merged, I plan to add new endpoint for creating new address for EOS-wallet.
