### PR TITLE
Only use a faucet when one is needed

### DIFF
--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -449,7 +449,7 @@ expectTxStatusEventually
 expectTxStatusEventually statuses = \case
     Left e    -> wantedSuccessButError e
     Right txn -> do
-        result <- ask >>= \ctx -> timeout (60 * second) (waitForTxStatus ctx statuses txn)
+        result <- ask >>= \ctx -> timeout (120 * second) (waitForTxStatus ctx statuses txn)
         case result of
             Nothing -> fail "expectTxStatusEventually: waited too long for statuses."
             Just _  -> return ()
@@ -465,7 +465,7 @@ expectTxStatusNever
 expectTxStatusNever statuses = \case
     Left e    -> wantedSuccessButError e
     Right txn -> do
-        result <- ask >>= \ctx -> timeout (60 * second) (waitForTxStatus ctx statuses txn)
+        result <- ask >>= \ctx -> timeout (120 * second) (waitForTxStatus ctx statuses txn)
         case result of
             Nothing -> return ()
             Just _  -> fail "expectTxStatusNever: reached one of the provided statuses."
@@ -479,7 +479,7 @@ expectWalletEventuallyRestored
 expectWalletEventuallyRestored = \case
     Left e -> wantedSuccessButError e
     Right w -> do
-        result <- ask >>= \ctx -> timeout (60 * second) (waitForRestored ctx w)
+        result <- ask >>= \ctx -> timeout (120 * second) (waitForRestored ctx w)
         case result of
             Nothing -> fail "expectWalletEventuallyRestored: waited too long for restoration."
             Just _  -> return ()

--- a/test/integration/configuration.yaml
+++ b/test/integration/configuration.yaml
@@ -22,7 +22,7 @@ default: &default
           seed: 0
         blockVersionData: &default_core_genesis_spec_blockVersionData
           scriptVersion:     0
-          slotDuration:      5000
+          slotDuration:      10000
           maxBlockSize:      2000000
           maxHeaderSize:     2000000
           maxTxSize:         4096 # 4 Kb
@@ -101,7 +101,7 @@ default: &default
     networkConnectionTimeout: 15000 # ms
     conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100
-    pendingTxResubmissionPeriod: 7 # seconds
+    pendingTxResubmissionPeriod: 60 # seconds
     walletProductionApi: false
     walletTxCreationDisabled: false
     explorerExtendedApi: false


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
<p align="right">#172</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have changed the `setupWallet` internal function from the DSL to only use get and use a faucet wallet when there's a need for one (i.e. when the fixture requires some initial coins).

# Comments

<!-- Additional comments or screenshots to attach if any -->

During integration test scenarios, a faucet wallet is needed only when
we require a wallet to have some initial coins. Quite a few scenarios
don't require this and therefore, we could save some faucet wallets (and
make the overall a bit faster) by just not getting one from the pool
when there's no need

This just stroke me as I was running the tests. We have a lot of faucet wallets but since we are extending the test suite quite a lot, we may hit that boundary sooner than we think.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
