### PR TITLE
WIP Modify fixture in newPayment for new address scheme

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/input-output-hk/cardano-sl
-  commit: cdc77284bde949d4b1b9ac7be81b76b906a71fc7
+  commit: 4ecd69bebd98c27d1d20d68c64293eb303a6cf8c
   subdirs:
     - acid-state-exts
     - binary

--- a/test/unit/Test/Spec/Ed25519Bip44.hs
+++ b/test/unit/Test/Spec/Ed25519Bip44.hs
@@ -23,6 +23,10 @@ import           Test.QuickCheck (Arbitrary (..), InfiniteList (..), Property,
                      arbitraryBoundedIntegral, arbitrarySizedBoundedIntegral,
                      property, shrinkIntegral, (.&&.), (===), (==>))
 
+-- TODO (akegalj): seems like there already is a notion of
+-- hardened vs non-hardened ix in Cardano.Wallet.Kernel.DB.HdWallet.Derivation module
+-- Consider using HardeningMode from that module instead of derivig it manually or merging these things together (ie, implementing Bounded and Arbitrary for them.
+
 -- A wrapper type for hardened keys generator
 newtype Hardened
     = Hardened Word32


### PR DESCRIPTION

This PR modifies fixtures in NewPayment spec so
that fixture now contains either old address scheme
or new address scheme.


<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#45</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added new type `AddressSchemeVersion` to distinguish between old scheme and new scheme
    - https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-30d40db9a639deefc7b1db60e7053813R600
- [x] I have partially extended how we can generate keys in cardano-sl crypto
   - https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-fafd0cdcd559a7b124cc61c29413fb54R7
   - https://github.com/input-output-hk/cardano-sl/commit/4ecd69bebd98c27d1d20d68c64293eb303a6cf8c
   - https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R133
- [x] I have added passphrase to fixtures as it is required for new derivation scheme
   - https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R83
 - [x] I have modified `prepareFixtures` so that it can mix old and new derivation/address scheme
   - https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R93

# Comments

<!-- Additional comments or screenshots to attach if any -->
Tests are passing currently passing if we choose to test old address scheme path only https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R94 . When new derivation scheme is choosen tests still fail and I have difficulties tracking this failure down. 

When `Kernel.AddressSchemeV1` is sellected, we are going to generate root/master key with https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R101 and we are going to generate addresses for our utxo with https://github.com/input-output-hk/cardano-wallet/pull/223/files#diff-849da1a7f8deb2932cb50ae0cbaa4d35R125 . 

With these changes to fixture, and running with `AddressSchemeV1` hardcoded tests are going to fail with `UnknownHdAccount`. When I tried to modify:

```haskell
        let accounts    = Kernel.prefilterUtxo newRootId esk utxo'
            hdAccountId = Kernel.defaultHdAccountId newRootId
            hdAddress   = Kernel.defaultHdAddress nm esk passPhrase newRootId
```

into 
```haskell
        let accounts    = Kernel.prefilterUtxo newRootId esk utxo'
            hdAccountId = newAccountId
            hdAddress   = Kernel.defaultHdAddress nm esk passPhrase newRootId
```
Which looks good from my perspective (am I right?) I will be start getting failure `UnknownHdAccountRoot`. If I try with:

```haskell
        let accounts    = Kernel.prefilterUtxo newRootId esk utxo'
            hdAccountId = newAccountId
            hdAddress   = Nothing
```
it will fail with ` CoinSelHardErrUtxoExhausted`. Long version is:

```
 NewPayment.EstimateFees, Estimating fees (wallet layer), estimating fees works (SenderPaysFee)
       uncaught exception: IOException of type UserError
       user error (EstimateFeesError EstFeesTxCreationFailed NewTransactionErrorCoinSelectionFailed CoinSelHardErrUtxoExhausted{ balance: 0 coin(s), value:   10 coin(s)})
```

And this is where I am going deeper into the problem but I am not sure should I - if not all bits are in place. Maybe its expected everything will still fail with this fixture update if other bits of bip44 feature is not complete. This way I am going through big chunks of code to get understanding and maybe that's wasting time. If this is a good dirrection - I am going to proceed with this method.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
