### PR TITLE
HdRootId as an opaque type

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -200,6 +200,7 @@ library
       Cardano.Wallet.Kernel.DB.EosHdWallet
       Cardano.Wallet.Kernel.DB.EosHdWallet.Create
       Cardano.Wallet.Kernel.DB.HdWallet
+      Cardano.Wallet.Kernel.DB.HdRootId
       Cardano.Wallet.Kernel.DB.HdWallet.Create
       Cardano.Wallet.Kernel.DB.HdWallet.Delete
       Cardano.Wallet.Kernel.DB.HdWallet.Derivation

--- a/src/Cardano/Wallet/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/Kernel/Accounts.hs
@@ -21,9 +21,10 @@ import           Pos.Crypto (EncryptedSecretKey, PassPhrase)
 
 import           Cardano.Wallet.Kernel.DB.AcidState (CreateHdAccount (..), DB,
                      DeleteHdAccount (..), UpdateHdAccountName (..))
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AccountName (..),
                      HdAccount (..), HdAccountId (..), HdAccountIx (..),
-                     HdAccountState (..), HdAccountUpToDate (..), HdRootId,
+                     HdAccountState (..), HdAccountUpToDate (..),
                      UnknownHdAccount (..), hdAccountName)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create
                      (CreateHdAccountError (..), initHdAccount)

--- a/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -71,6 +71,7 @@ import           Pos.Crypto (PublicKey)
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.EosHdWallet
 import qualified Cardano.Wallet.Kernel.DB.EosHdWallet.Create as EosHD
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Delete as HD

--- a/src/Cardano/Wallet/Kernel/DB/HdRootId.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdRootId.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Cardano.Wallet.Kernel.DB.HdRootId (
+      HdRootId
+    , decodeHdRootId
+    , mkHdRootIdForEOWallet
+    , mkHdRootIdForFOWallet
+    ) where
+
+import           Universum
+
+import           Data.ByteString.Base58 (bitcoinAlphabet, decodeBase58,
+                     encodeBase58)
+import           Data.SafeCopy (base, deriveSafeCopy)
+import qualified Data.UUID as Uuid
+import           Data.UUID.V4 (nextRandom)
+
+import           Test.QuickCheck (Arbitrary (..))
+import           Test.QuickCheck.Gen (oneof)
+
+import           Formatting (bprint, build)
+import qualified Formatting.Buildable
+
+import qualified Pos.Binary.Class as Bi
+import qualified Pos.Core as Core
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Crypto (EncryptedSecretKey, encToPublic)
+
+-- | Unified identifier for wallets (both FO and EO ones).
+-- Technically it contains a text, but actually it contains one from two options:
+--
+-- 1. for FO-wallets - 'Core.Address' made from wallet's root public key, in Base58-format.
+-- 2. for EO-wallets - 'UUID', in Base58-format.
+--
+-- Please note that using 'Core.Address' as wallet's identifier is a bad decision,
+-- but since exchanges and users may have wallets' ids stored on their side we
+-- have to keep backward-compatibility for existing ids.
+newtype HdRootId = HdRootId { getHdRootId :: Text }
+    deriving (Eq, Ord, Show, Generic)
+
+instance NFData HdRootId
+
+-- | TODO: It is not very arbitrary, maybe we should improve it.
+instance Arbitrary HdRootId where
+    arbitrary = oneof
+        [ pure $ HdRootId "Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx"
+        , pure $ HdRootId "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+        , pure $ HdRootId "kKyjp8hUCYDK1UhU8Wg5sBu3Ud2TqFDCbTWCo9ySDGjaLLk73"
+        , pure $ HdRootId "QxUZbMEK9Vg6V9UWQ1BRLwrBoQQuYt2RjnEW4vRmXBtsT9WKk"
+        , pure $ HdRootId "maKVJgoL6c65NfUJDGeyQhcK6b9rynpEdwKe4T1wn3jfEZZRv"
+        , pure $ HdRootId "SC6jKYB9gFnNhvZNuQW6e7MnWM59pwcyNp1ayp9n9iEiucYWr"
+        , pure $ HdRootId "RqTmjdzemFRaZzu4TZH9qwS5NefKgTZ6fp2bELoX8hwJPSuBw"
+        ]
+
+instance Buildable HdRootId where
+    build (HdRootId uniqueId) = bprint build uniqueId
+
+deriveSafeCopy 1 'base ''HdRootId
+
+-- | Decodes 'HdRootId' from the text.
+decodeHdRootId :: Text -> Either Text HdRootId
+decodeHdRootId rawId = decodeFromBS . encodeUtf8 $ rawId
+  where
+    decodeFromBS :: ByteString -> Either Text HdRootId
+    decodeFromBS bs = do
+        let base58Err = "Invalid Base58 representation of HdRootId"
+        decodedBS <- maybeToRight base58Err $ decodeBase58 bitcoinAlphabet bs
+        let probablyUUID = decodeUUID decodedBS
+            probablyAddress = decodeAddress decodedBS
+        if isRight probablyUUID
+            then probablyUUID
+            else probablyAddress
+
+    decodeUUID bs = maybe
+        (Left ("HdRootId is not a UUID" :: Text))
+        (\_ -> Right $ HdRootId rawId)
+        $ Uuid.fromASCIIBytes bs
+
+    decodeAddress bs = either
+        (\_ -> Left "Invalid HdRootId (it's not an Address nor UUID)")
+        (\(_addr :: Core.Address) -> Right $ HdRootId rawId)
+        $ Bi.decodeFull' bs
+
+mkHdRootIdForEOWallet :: IO HdRootId
+mkHdRootIdForEOWallet = HdRootId
+    . decodeUtf8
+    . encodeBase58 bitcoinAlphabet
+    . Uuid.toASCIIBytes <$> nextRandom
+
+mkHdRootIdForFOWallet
+    :: NetworkMagic
+    -> EncryptedSecretKey
+    -> HdRootId
+mkHdRootIdForFOWallet nm esk = HdRootId
+    . decodeUtf8
+    . Core.addrToBase58
+    . (Core.makePubKeyAddressBoot nm)
+    . encToPublic $ esk

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -26,6 +26,7 @@ import qualified Formatting.Buildable
 
 import qualified Pos.Core as Core
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Util.AcidState

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
@@ -10,6 +10,7 @@ import           Universum
 
 import           Control.Lens (at, (.=))
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.Util.AcidState
 import           Cardano.Wallet.Kernel.DB.Util.IxSet (ixedIndexed)

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
@@ -38,6 +38,7 @@ import           Pos.Chain.Txp (TxId, Utxo)
 import           Pos.Core (Address, Coin, SlotId, mkCoin, unsafeAddCoin)
 
 import           Cardano.Wallet.Kernel.DB.BlockMeta (AddressMeta)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Spec (IsCheckpoint (..),

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
@@ -7,6 +7,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet.Update (
 
 import           Universum
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.Util.AcidState
 import           UTxO.Util (modifyAndGetNew)

--- a/src/Cardano/Wallet/Kernel/DB/Read.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Read.hs
@@ -32,6 +32,7 @@ import           Pos.Core (Address, Coin, SlotId)
 
 import           Cardano.Wallet.Kernel.DB.AcidState (DB, dbHdWallets)
 import           Cardano.Wallet.Kernel.DB.BlockMeta (AddressMeta)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Read as HD
 import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)

--- a/src/Cardano/Wallet/Kernel/DB/Resolved.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Resolved.hs
@@ -30,9 +30,8 @@ import           Serokell.Util (listJson, mapJson, pairF)
 
 import           Cardano.Wallet.Kernel.DB.BlockContext (BlockContext)
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId (..),
-                     HdAccountIx (..), HdRootId (..), IsOurs (..),
-                     hdAccountIdIx, hdAccountIdParent, hdAddressId,
-                     hdAddressIdParent)
+                     HdAccountIx (..), IsOurs (..), hdAccountIdIx,
+                     hdAccountIdParent, hdAddressId, hdAddressIdParent)
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
 import           Cardano.Wallet.Kernel.DB.TxMeta.Types (TxMeta (..))
 import           Cardano.Wallet.Kernel.Util.Core (absCoin, sumCoinsUnsafe)
@@ -113,7 +112,7 @@ resolvedToTxMetas rb = runState $ runExceptT $ fmap mconcat $ do
                 , _txMetaCreationAt = tx ^. rtxMeta . fromDb . _2
                 , _txMetaIsLocal = isLocal
                 , _txMetaIsOutgoing = gained < spent
-                , _txMetaWalletId = view fromDb $ getHdRootId $ accId ^. hdAccountIdParent
+                , _txMetaWalletId = accId ^. hdAccountIdParent
                 , _txMetaAccountIx = getHdAccountIx $ accId ^. hdAccountIdIx
                 }
   where

--- a/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
+++ b/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
@@ -338,8 +338,8 @@ instance FromField HdRootId where
     fromField f = do
         rootId <- decodeHdRootId <$> fromField f
         case rootId of
-           Left _  -> returnError Sqlite.ConversionFailed f "not a valid HdRootId"
-           Right a -> pure a
+           Nothing -> returnError Sqlite.ConversionFailed f "not a valid HdRootId"
+           Just a  -> pure a
 
 instance FromBackendRow Sqlite Core.Address
 

--- a/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
+++ b/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
@@ -61,6 +61,8 @@ import           Test.QuickCheck (Arbitrary (..), Gen)
 import qualified Pos.Chain.Txp as Txp
 import qualified Pos.Core as Core
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
+
 import           Test.Pos.Core.Arbitrary ()
 
 {-------------------------------------------------------------------------------
@@ -100,7 +102,7 @@ data TxMeta = TxMeta {
     , _txMetaIsOutgoing :: Bool
 
       -- The Wallet that added this Tx.
-    , _txMetaWalletId   :: Core.Address
+    , _txMetaWalletId   :: HdRootId
 
       -- The account index that added this Tx
     , _txMetaAccountIx  :: Word32
@@ -150,7 +152,7 @@ txIdIsomorphic t1 t2 =
         ]
 
 type AccountIx = Word32
-type WalletId = Core.Address
+type WalletId = HdRootId
 -- | Filter Operations on Accounts. This is hiererchical: you can`t have AccountIx without WalletId.
 data AccountFops = Everything | AccountFops WalletId (Maybe AccountIx)
 
@@ -292,8 +294,8 @@ data MetaDBHandle = MetaDBHandle {
       closeMetaDB   :: IO ()
     , migrateMetaDB :: IO ()
     , clearMetaDB   :: IO ()
-    , deleteTxMetas :: Core.Address -> Maybe Word32 -> IO ()
-    , getTxMeta     :: Txp.TxId -> Core.Address -> Word32 -> IO (Maybe TxMeta)
+    , deleteTxMetas :: HdRootId -> Maybe Word32 -> IO ()
+    , getTxMeta     :: Txp.TxId -> HdRootId -> Word32 -> IO (Maybe TxMeta)
     , putTxMeta     :: TxMeta -> IO ()
     , putTxMetaT    :: TxMeta -> IO PutReturn
     , getAllTxMetas :: IO [TxMeta]

--- a/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/src/Cardano/Wallet/Kernel/Internal.hs
@@ -59,7 +59,7 @@ import           Pos.Util.Wlog (Severity (..))
 import           Cardano.Wallet.API.Types.UnitOfMeasure (MeasuredIn (..),
                      UnitOfMeasure (..))
 import           Cardano.Wallet.Kernel.DB.AcidState (DB)
-import           Cardano.Wallet.Kernel.DB.HdWallet (HdRootId)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.TxMeta
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 import           Cardano.Wallet.Kernel.Keystore (Keystore)

--- a/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -44,7 +44,8 @@ import           Pos.Util.UserSecret (UserSecret, getUSPath, isEmptyUserSecret,
                      writeRaw, writeUserSecretRelease, _wusRootKey)
 import           Pos.Util.Wlog (addLoggerName)
 
-import           Cardano.Wallet.Kernel.DB.HdWallet (HdRootId, eskToHdRootId)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
+                     mkHdRootIdForFOWallet)
 import qualified Cardano.Wallet.Kernel.Util.Strict as Strict
 
 -- Internal storage necessary to smooth out the legacy 'UserSecret' API.
@@ -266,7 +267,7 @@ lookup nm wId (Keystore ks) =
 -- | Lookup a key directly inside the 'UserSecret'.
 lookupKey :: NetworkMagic -> UserSecret -> HdRootId -> Maybe EncryptedSecretKey
 lookupKey nm us walletId =
-    Data.List.find (\k -> eskToHdRootId nm k == walletId) (us ^. usKeys)
+    Data.List.find (\k -> mkHdRootIdForFOWallet nm k == walletId) (us ^. usKeys)
 
 -- | Return all Keystore 'usKeys'
 getKeys :: Keystore -> IO [EncryptedSecretKey]

--- a/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -44,8 +44,7 @@ import           Pos.Util.UserSecret (UserSecret, getUSPath, isEmptyUserSecret,
                      writeRaw, writeUserSecretRelease, _wusRootKey)
 import           Pos.Util.Wlog (addLoggerName)
 
-import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
-                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import qualified Cardano.Wallet.Kernel.Util.Strict as Strict
 
 -- Internal storage necessary to smooth out the legacy 'UserSecret' API.
@@ -267,7 +266,7 @@ lookup nm wId (Keystore ks) =
 -- | Lookup a key directly inside the 'UserSecret'.
 lookupKey :: NetworkMagic -> UserSecret -> HdRootId -> Maybe EncryptedSecretKey
 lookupKey nm us walletId =
-    Data.List.find (\k -> mkHdRootIdForFOWallet nm k == walletId) (us ^. usKeys)
+    Data.List.find (\k -> eskToHdRootId nm k == walletId) (us ^. usKeys)
 
 -- | Return all Keystore 'usKeys'
 getKeys :: Keystore -> IO [EncryptedSecretKey]

--- a/src/Cardano/Wallet/Kernel/Migration.hs
+++ b/src/Cardano/Wallet/Kernel/Migration.hs
@@ -15,6 +15,7 @@ import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Util.Wlog (Severity (..))
 
 import qualified Cardano.Wallet.Kernel as Kernel
+import           Cardano.Wallet.Kernel.DB.HdRootId (mkHdRootIdForFOWallet)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import           Cardano.Wallet.Kernel.Keystore as Keystore
@@ -101,7 +102,7 @@ restore :: Kernel.PassiveWallet
 restore pw forced esk = do
     let logMsg = pw ^. Kernel.walletLogMessage
         nm     = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
-        rootId = HD.eskToHdRootId nm esk
+        rootId = mkHdRootIdForFOWallet nm esk
 
     let -- DEFAULTS for wallet restoration
         -- we don't have a spending password during migration

--- a/src/Cardano/Wallet/Kernel/Migration.hs
+++ b/src/Cardano/Wallet/Kernel/Migration.hs
@@ -15,7 +15,7 @@ import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Util.Wlog (Severity (..))
 
 import qualified Cardano.Wallet.Kernel as Kernel
-import           Cardano.Wallet.Kernel.DB.HdRootId (mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (eskToHdRootId)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import           Cardano.Wallet.Kernel.Keystore as Keystore
@@ -102,7 +102,7 @@ restore :: Kernel.PassiveWallet
 restore pw forced esk = do
     let logMsg = pw ^. Kernel.walletLogMessage
         nm     = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
-        rootId = mkHdRootIdForFOWallet nm esk
+        rootId = eskToHdRootId nm esk
 
     let -- DEFAULTS for wallet restoration
         -- we don't have a spending password during migration

--- a/src/Cardano/Wallet/Kernel/Pending.hs
+++ b/src/Cardano/Wallet/Kernel/Pending.hs
@@ -22,6 +22,7 @@ import           Pos.Crypto (EncryptedSecretKey)
 import           Cardano.Wallet.Kernel.DB.AcidState (CancelPending (..),
                      NewForeign (..), NewForeignError (..), NewPending (..),
                      NewPendingError (..))
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.InDb
 import qualified Cardano.Wallet.Kernel.DB.Spec.Pending as Pending

--- a/src/Cardano/Wallet/Kernel/Read.hs
+++ b/src/Cardano/Wallet/Kernel/Read.hs
@@ -21,7 +21,7 @@ import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Util.Wlog (Severity (..))
 
 import           Cardano.Wallet.Kernel.DB.AcidState (DB, Snapshot (..))
-import           Cardano.Wallet.Kernel.DB.HdWallet (HdRootId)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.Read as Getters
 import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore

--- a/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/src/Cardano/Wallet/Kernel/Restore.hs
@@ -34,6 +34,7 @@ import           Cardano.Wallet.Kernel.DB.AcidState (ApplyHistoricalBlocks (..),
                      RestorationComplete (..), RestoreHdWallet (..),
                      dbHdWallets)
 import           Cardano.Wallet.Kernel.DB.BlockContext
+import qualified Cardano.Wallet.Kernel.DB.HdRootId as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (CreateHdRootError)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
@@ -139,7 +140,7 @@ restoreWallet pw hasSpendingPassword defaultCardanoAddress name assurance esk = 
 
   where
     nm = makeNetworkMagic (pw ^. walletProtocolMagic)
-    creds = (HD.eskToHdRootId nm esk, esk)
+    creds = (HD.mkHdRootIdForFOWallet nm esk, esk)
 
     prefilter :: Blund -> IO (PrefilteredBlock, [TxMeta])
     prefilter = mkPrefilter pw creds

--- a/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/src/Cardano/Wallet/Kernel/Restore.hs
@@ -140,7 +140,7 @@ restoreWallet pw hasSpendingPassword defaultCardanoAddress name assurance esk = 
 
   where
     nm = makeNetworkMagic (pw ^. walletProtocolMagic)
-    creds = (HD.mkHdRootIdForFOWallet nm esk, esk)
+    creds = (HD.eskToHdRootId nm esk, esk)
 
     prefilter :: Blund -> IO (PrefilteredBlock, [TxMeta])
     prefilter = mkPrefilter pw creds

--- a/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -51,7 +51,7 @@ import           Cardano.Wallet.Kernel.DB.AcidState (DB, NewForeignError,
                      NewPendingError)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
-import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import           Cardano.Wallet.Kernel.DB.Read as Getters
 import           Cardano.Wallet.Kernel.DB.TxMeta.Types
 import           Cardano.Wallet.Kernel.Ed25519Bip44
@@ -460,7 +460,7 @@ metaForNewTx time accountId txId inputs outputs allInpOurs spentInputsCoins allO
         , _txMetaCreationAt = time
         , _txMetaIsLocal = allInpOurs && allOutOurs
         , _txMetaIsOutgoing = gainedOutputsCoins < spentInputsCoins -- it`s outgoing if our inputs spent are more than the new utxo.
-        , _txMetaWalletId = _fromDb $ getHdRootId (accountId ^. hdAccountIdParent)
+        , _txMetaWalletId = accountId ^. hdAccountIdParent
         , _txMetaAccountIx = getHdAccountIx $ accountId ^. hdAccountIdIx
     }
   where
@@ -759,7 +759,7 @@ redeemAda w@ActiveWallet{..} accId pw rsk = runExceptT $ do
               , _txMetaCreationAt = now
               , _txMetaIsLocal    = False -- input does not belong to wallet
               , _txMetaIsOutgoing = False -- increases wallet's balance
-              , _txMetaWalletId   = _fromDb $ getHdRootId (accId ^. hdAccountIdParent)
+              , _txMetaWalletId   = accId ^. hdAccountIdParent
               , _txMetaAccountIx  = getHdAccountIx (accId ^. hdAccountIdIx)
               }
         return (txAux, txMeta)

--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -40,10 +40,10 @@ import           Cardano.Wallet.Kernel.DB.AcidState (CreateEosHdWallet (..),
                      UpdateHdRootPassword (..), UpdateHdWallet (..))
 import           Cardano.Wallet.Kernel.DB.EosHdWallet (EosHdRoot (..))
 import qualified Cardano.Wallet.Kernel.DB.EosHdWallet.Create as EosHD
+import qualified Cardano.Wallet.Kernel.DB.HdRootId as HD
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel,
                      HdAccountId (..), HdAccountIx (..), HdAddress,
-                     HdAddressId (..), HdAddressIx (..), HdRoot, HdRootId,
-                     WalletName, eskToHdRootId)
+                     HdAddressId (..), HdAddressIx (..), HdRoot, WalletName)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
@@ -183,7 +183,7 @@ createHdWallet pw mnemonic spendingPassword assuranceLevel walletName = do
     -- (We got interrupted before inserting it) causing a system panic.
     -- We can fix this properly as part of [CBR-404].
     let nm = makeNetworkMagic (pw ^. walletProtocolMagic)
-        newRootId = eskToHdRootId nm esk
+        newRootId = HD.mkHdRootIdForFOWallet nm esk
     Keystore.insert newRootId esk (pw ^. walletKeystore)
 
     -- STEP 2.5: Generate the fresh Cardano Address which will be used for the
@@ -299,7 +299,7 @@ createWalletHdRnd :: PassiveWallet
 createWalletHdRnd pw hasSpendingPassword defaultCardanoAddress name assuranceLevel esk createWallet = do
     created <- InDb <$> getCurrentTimestamp
     let nm      = makeNetworkMagic (pw ^. walletProtocolMagic)
-        rootId  = eskToHdRootId nm esk
+        rootId  = HD.mkHdRootIdForFOWallet nm esk
         newRoot = HD.initHdRoot rootId
                                 name
                                 (hdSpendingPassword created)
@@ -352,10 +352,10 @@ defaultHdAddressWith :: EncryptedSecretKey
 defaultHdAddressWith esk rootId addr =
     fst $ HD.isOurs addr [(rootId, esk)]
 
-defaultHdAccountId :: HdRootId -> HdAccountId
+defaultHdAccountId :: HD.HdRootId -> HdAccountId
 defaultHdAccountId rootId = HdAccountId rootId (HdAccountIx firstHardened)
 
-defaultHdAddressId :: HdRootId -> HdAddressId
+defaultHdAddressId :: HD.HdRootId -> HdAddressId
 defaultHdAddressId rootId =
     HdAddressId (defaultHdAccountId rootId) (HdAddressIx firstHardened)
 

--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -183,7 +183,7 @@ createHdWallet pw mnemonic spendingPassword assuranceLevel walletName = do
     -- (We got interrupted before inserting it) causing a system panic.
     -- We can fix this properly as part of [CBR-404].
     let nm = makeNetworkMagic (pw ^. walletProtocolMagic)
-        newRootId = HD.mkHdRootIdForFOWallet nm esk
+        newRootId = HD.eskToHdRootId nm esk
     Keystore.insert newRootId esk (pw ^. walletKeystore)
 
     -- STEP 2.5: Generate the fresh Cardano Address which will be used for the
@@ -299,7 +299,7 @@ createWalletHdRnd :: PassiveWallet
 createWalletHdRnd pw hasSpendingPassword defaultCardanoAddress name assuranceLevel esk createWallet = do
     created <- InDb <$> getCurrentTimestamp
     let nm      = makeNetworkMagic (pw ^. walletProtocolMagic)
-        rootId  = HD.mkHdRootIdForFOWallet nm esk
+        rootId  = HD.eskToHdRootId nm esk
         newRoot = HD.initHdRoot rootId
                                 name
                                 (hdSpendingPassword created)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Accounts.hs
@@ -22,7 +22,6 @@ import           Cardano.Wallet.API.V1.Types (WalletAddress)
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
-import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import           Cardano.Wallet.Kernel.DB.Read (addressesByAccountId)
 import qualified Cardano.Wallet.Kernel.DB.TxMeta.Types as Kernel
 import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed (..), IxSet)
@@ -128,9 +127,8 @@ deleteAccount wallet wId accIx = runExceptT $ do
     accId <- withExceptT DeleteAccountWalletIdDecodingFailed $
         fromAccountId wId accIx
     withExceptT DeleteAccountError $ ExceptT $ liftIO $ do
-        let walletId = HD.getHdRootId rootId ^. fromDb
         let accountIx = Just $ V1.getAccIndex accIx
-        Kernel.deleteTxMetas (wallet ^. Kernel.walletMeta) walletId accountIx
+        Kernel.deleteTxMetas (wallet ^. Kernel.walletMeta) rootId accountIx
         Kernel.deleteAccount accId wallet
 
 updateAccount :: MonadIO m

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -69,8 +69,10 @@ import           UTxO.Util (exceptT)
 -------------------------------------------------------------------------------}
 
 fromRootId :: Monad m => V1.WalletId -> ExceptT Text m HD.HdRootId
-fromRootId (V1.WalletId wId) =
-    exceptT (HD.decodeHdRootId wId)
+fromRootId (V1.WalletId wId) = exceptT $ maybe
+    (Left $ "fromRootId: can't decode given Text to HdRootId: " <> wId)
+    Right
+    (HD.decodeHdRootId wId)
 
 fromAccountId :: Monad m
               => V1.WalletId -> V1.AccountIndex -> ExceptT Text m HD.HdAccountId

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -112,8 +112,8 @@ castAccountFiltering mbWalletId mbAccountIndex =
         -- AccountIndex doesn`t uniquely identify an Account, so we shouldn`t continue without a WalletId.
         (Just (V1.WalletId wId), _) ->
             case HD.decodeHdRootId wId of
-                Left _       -> throwError $ GetTxAddressDecodingFailed wId
-                Right rootId -> return $ TxMeta.AccountFops rootId (V1.getAccIndex <$> mbAccountIndex)
+                Nothing     -> throwError $ GetTxAddressDecodingFailed wId
+                Just rootId -> return $ TxMeta.AccountFops rootId (V1.getAccIndex <$> mbAccountIndex)
 
 -- This function reads at most the head of the SortOperations and expects to find "created_at".
 castSorting :: Monad m => S.SortOperations V1.Transaction -> ExceptT GetTxError m (Maybe TxMeta.Sorting)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -11,8 +11,8 @@ import           Control.Monad.Except
 import           Formatting (build, sformat)
 import           GHC.TypeLits (symbolVal)
 
-import           Pos.Core (Address, Coin, SlotCount, SlotId, decodeTextAddress,
-                     flattenSlotId, getBlockCount)
+import           Pos.Core (Address, Coin, SlotCount, SlotId, flattenSlotId,
+                     getBlockCount)
 import           Pos.Node.API (unV1)
 import           Pos.Util.Wlog (Severity (..))
 
@@ -23,8 +23,8 @@ import           Cardano.Wallet.API.Request.Pagination
 import qualified Cardano.Wallet.API.Request.Sort as S
 import           Cardano.Wallet.API.Response
 import qualified Cardano.Wallet.API.V1.Types as V1
+import qualified Cardano.Wallet.Kernel.DB.HdRootId as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import           Cardano.Wallet.Kernel.DB.TxMeta (TxMeta (..))
 import qualified Cardano.Wallet.Kernel.DB.TxMeta as TxMeta
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
@@ -111,9 +111,9 @@ castAccountFiltering mbWalletId mbAccountIndex =
         (Nothing, Just _)  -> throwError GetTxMissingWalletIdError
         -- AccountIndex doesn`t uniquely identify an Account, so we shouldn`t continue without a WalletId.
         (Just (V1.WalletId wId), _) ->
-            case decodeTextAddress wId of
-                Left _         -> throwError $ GetTxAddressDecodingFailed wId
-                Right rootAddr -> return $ TxMeta.AccountFops rootAddr (V1.getAccIndex <$> mbAccountIndex)
+            case HD.decodeHdRootId wId of
+                Left _       -> throwError $ GetTxAddressDecodingFailed wId
+                Right rootId -> return $ TxMeta.AccountFops rootId (V1.getAccIndex <$> mbAccountIndex)
 
 -- This function reads at most the head of the SortOperations and expects to find "created_at".
 castSorting :: Monad m => S.SortOperations V1.Transaction -> ExceptT GetTxError m (Maybe TxMeta.Sorting)
@@ -166,7 +166,7 @@ metaToTx db slotCount current TxMeta{..} = do
         txStatus = status
     }
         where
-            hdRootId    = HD.HdRootId $ InDb _txMetaWalletId
+            hdRootId    = _txMetaWalletId
             hdAccountId = HD.HdAccountId hdRootId (HD.HdAccountIx _txMetaAccountIx)
 
             inputsToPayDistr :: (a , b, Address, Coin) -> V1.PaymentDistribution

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -99,7 +99,7 @@ createWallet wallet newWalletRequest = liftIO $ do
                    -> HD.AssuranceLevel
                    -> IO (Either CreateWalletError V1.Wallet)
     restoreFromESK nm esk pwd walletName hdAssuranceLevel = runExceptT $ do
-        let rootId = HD.mkHdRootIdForFOWallet nm esk
+        let rootId = HD.eskToHdRootId nm esk
 
         -- Insert the 'EncryptedSecretKey' into the 'Keystore'
         liftIO $ Keystore.insert rootId esk (wallet ^. walletKeystore)

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -29,6 +29,7 @@ import           Cardano.Wallet.Kernel.Addresses (newHdAddress)
 import           Cardano.Wallet.Kernel.AddressPoolGap (AddressPoolGap)
 import           Cardano.Wallet.Kernel.DB.AcidState (dbHdWallets)
 import qualified Cardano.Wallet.Kernel.DB.EosHdWallet as EosHD
+import qualified Cardano.Wallet.Kernel.DB.HdRootId as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import qualified Cardano.Wallet.Kernel.DB.TxMeta.Types as Kernel
@@ -98,7 +99,7 @@ createWallet wallet newWalletRequest = liftIO $ do
                    -> HD.AssuranceLevel
                    -> IO (Either CreateWalletError V1.Wallet)
     restoreFromESK nm esk pwd walletName hdAssuranceLevel = runExceptT $ do
-        let rootId = HD.eskToHdRootId nm esk
+        let rootId = HD.mkHdRootIdForFOWallet nm esk
 
         -- Insert the 'EncryptedSecretKey' into the 'Keystore'
         liftIO $ Keystore.insert rootId esk (wallet ^. walletKeystore)
@@ -220,9 +221,8 @@ deleteWallet wallet wId = runExceptT $ do
     rootId <- withExceptT DeleteWalletWalletIdDecodingFailed $ fromRootId wId
     withExceptT DeleteWalletError $ ExceptT $ liftIO $ do
         let nm = makeNetworkMagic (wallet ^. walletProtocolMagic)
-        let walletId = HD.getHdRootId rootId ^. fromDb
         Kernel.removeRestoration wallet rootId
-        Kernel.deleteTxMetas (wallet ^. walletMeta) walletId Nothing
+        Kernel.deleteTxMetas (wallet ^. walletMeta) rootId Nothing
         Kernel.deleteHdWallet nm wallet rootId
 
 -- | Deletes external wallets. Please note that there's no actions in the

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -30,8 +30,7 @@ import           Cardano.Wallet.API.V1.Handlers.Addresses as Handlers
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.DB.AcidState
-import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
-                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
                      HasSpendingPassword (..), HdAccountId (..),
                      HdAccountIx (..), WalletName (..))
@@ -75,7 +74,7 @@ data AddressFixture = AddressFixture {
 prepareFixtures :: NetworkMagic -> Fixture.GenPassiveWalletFixture Fixture
 prepareFixtures nm = do
     let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
-    let newRootId = mkHdRootIdForFOWallet nm esk
+    let newRootId = eskToHdRootId nm esk
     now <- getCurrentTimestamp
     newRoot <- initHdRoot <$> pure newRootId
                           <*> pure (WalletName "A wallet")

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -30,14 +30,15 @@ import           Cardano.Wallet.API.V1.Handlers.Addresses as Handlers
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.DB.AcidState
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
+                     mkHdRootIdForFOWallet)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
                      HasSpendingPassword (..), HdAccountId (..),
-                     HdAccountIx (..), HdRootId (..), WalletName (..),
-                     eskToHdRootId)
+                     HdAccountIx (..), WalletName (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (initHdRoot)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
+import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import           Cardano.Wallet.Kernel.Internal (PassiveWallet, wallets)
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
@@ -74,7 +75,7 @@ data AddressFixture = AddressFixture {
 prepareFixtures :: NetworkMagic -> Fixture.GenPassiveWalletFixture Fixture
 prepareFixtures nm = do
     let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
-    let newRootId = eskToHdRootId nm esk
+    let newRootId = mkHdRootIdForFOWallet nm esk
     now <- getCurrentTimestamp
     newRoot <- initHdRoot <$> pure newRootId
                           <*> pure (WalletName "A wallet")
@@ -209,8 +210,7 @@ spec = describe "Addresses" $ do
                     pm <- pick arbitrary
                     withFixture pm $ \keystore layer _ Fixture{..} -> do
                         Keystore.insert fixtureHdRootId fixtureESK keystore
-                        let (HdRootId hdRoot) = fixtureHdRootId
-                            wId = sformat build (view fromDb hdRoot)
+                        let wId = sformat build fixtureHdRootId
                             accIdx = Kernel.Conv.toAccountId fixtureAccountId
                         res <- WalletLayer.createAddress layer (V1.NewAddress Nothing accIdx (V1.WalletId wId))
                         (bimap STB STB res) `shouldSatisfy` isRight
@@ -250,8 +250,7 @@ spec = describe "Addresses" $ do
                     pm <- pick arbitrary
                     withFixture pm $ \keystore layer _ Fixture{..} -> do
                         Keystore.insert fixtureHdRootId fixtureESK keystore
-                        let (HdRootId hdRoot) = fixtureHdRootId
-                            wId = sformat build (view fromDb hdRoot)
+                        let wId = sformat build fixtureHdRootId
                             accIdx = Kernel.Conv.toAccountId fixtureAccountId
                             req = V1.NewAddress Nothing accIdx (V1.WalletId wId)
                         res <- runExceptT . runHandler' $ Handlers.newAddress layer req
@@ -266,8 +265,7 @@ spec = describe "Addresses" $ do
                         Kernel.createAddress mempty fixtureAccountId fixturePw
                     res2 <- withFixture pm $ \keystore layer _ Fixture{..} -> do
                         Keystore.insert fixtureHdRootId fixtureESK keystore
-                        let (HdRootId hdRoot) = fixtureHdRootId
-                            wId = sformat build (view fromDb hdRoot)
+                        let wId = sformat build fixtureHdRootId
                             accIdx = Kernel.Conv.toAccountId fixtureAccountId
                         WalletLayer.createAddress layer (V1.NewAddress Nothing accIdx (V1.WalletId wId))
                     case res2 of

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -43,15 +43,16 @@ import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
                      (CoinSelectionOptions (..), ExpenseRegulation (..),
                      InputGrouping (..), newOptions)
 import           Cardano.Wallet.Kernel.DB.AcidState
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, decodeHdRootId)
+import           Cardano.Wallet.Kernel.DB.HdRootId (mkHdRootIdForFOWallet)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
                      HasSpendingPassword (..), HdAccountId (..),
                      HdAccountIx (..), HdAddressIx (..), HdRoot (..),
-                     HdRootId (..), WalletName (..), eskToHdRootId,
-                     hdAccountIdIx)
+                     WalletName (..), hdAccountIdIx)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (initHdRoot)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
+import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import           Cardano.Wallet.Kernel.DB.TxMeta
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import           Cardano.Wallet.Kernel.Internal
@@ -99,7 +100,7 @@ prepareFixtures :: NetworkMagic
 prepareFixtures nm initialBalance = do
     fixt <- forM [0x11, 0x22] $ \b -> do
         let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 b) mempty
-        let newRootId = eskToHdRootId nm esk
+        let newRootId = mkHdRootIdForFOWallet nm esk
         now <- getCurrentTimestamp
         newRoot <- initHdRoot <$> pure newRootId
                             <*> pure (WalletName "A wallet")
@@ -215,15 +216,14 @@ spec = do
                 pm          <- pick arbitrary
                 Addresses.withFixture pm $ \keystore layer pwallet Addresses.Fixture{..} -> do
                     liftIO $ Keystore.insert fixtureHdRootId fixtureESK keystore
-                    let (HdRootId hdRoot) = fixtureHdRootId
-                        wId = sformat build (view fromDb hdRoot)
+                    let wId = sformat build fixtureHdRootId
                         accIdx = fixtureAccountId ^. hdAccountIdIx . to getHdAccountIx
                         hdl = (pwallet ^. Kernel.walletMeta)
                         testMeta = unSTB testMetaSTB
-                    case decodeTextAddress wId of
-                        Left _         -> expectationFailure "decodeTextAddress failed"
-                        Right rootAddr -> do
-                            let meta = testMeta {_txMetaWalletId = rootAddr, _txMetaAccountIx = accIdx}
+                    case decodeHdRootId wId of
+                        Left _       -> expectationFailure "decodeHdRootId failed"
+                        Right rootId -> do
+                            let meta = testMeta {_txMetaWalletId = rootId, _txMetaAccountIx = accIdx}
                             _ <- liftIO $ WalletLayer.createAddress layer
                                     (V1.NewAddress
                                         Nothing
@@ -264,8 +264,7 @@ spec = do
                 pm <- pick arbitrary
                 NewPayment.withFixture @IO pm (InitialADA 10000) (PayLovelace 25) $ \keystore activeLayer aw NewPayment.Fixture{..} -> do
                     liftIO $ Keystore.insert fixtureHdRootId fixtureESK keystore
-                    let (HdRootId (InDb rootAddress)) = fixtureHdRootId
-                    let sourceWallet = V1.WalletId (sformat build rootAddress)
+                    let sourceWallet = V1.WalletId (sformat build fixtureHdRootId)
                     let accountIndex = Kernel.Conv.toAccountId fixtureAccountId
                     let destinations =
                             fmap (\(addr, coin) -> V1.PaymentDistribution (V1.WalAddress addr) (V1.WalletCoin coin)
@@ -287,8 +286,7 @@ spec = do
                             let txid = _txMetaId meta
                                 pw = Kernel.walletPassive aw
                                 layer = walletPassiveLayer activeLayer
-                                (HdRootId hdRoot) = fixtureHdRootId
-                                wId = sformat build (view fromDb hdRoot)
+                                wId = sformat build fixtureHdRootId
                                 accIdx = Kernel.Conv.toAccountId fixtureAccountId
                                 hdl = (pw ^. Kernel.walletMeta)
                             db <- Kernel.getWalletSnapshot pw

--- a/test/unit/Test/Spec/Keystore.hs
+++ b/test/unit/Test/Spec/Keystore.hs
@@ -19,8 +19,7 @@ import           Test.QuickCheck.Monadic (forAllM, monadicIO, pick, run)
 import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, hash, safeKeyGen)
 
-import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
-                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet ()
 import           Cardano.Wallet.Kernel.Keystore (DeletePolicy (..), Keystore)
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
@@ -40,7 +39,7 @@ genKeypair :: NetworkMagic
                   )
 genKeypair nm = do
     (_, esk) <- arbitrary >>= safeKeyGen
-    return $ bimap STB STB (mkHdRootIdForFOWallet nm esk, esk)
+    return $ bimap STB STB (eskToHdRootId nm esk, esk)
 
 genKeys :: NetworkMagic
         -> Gen ( ShowThroughBuild HdRootId

--- a/test/unit/Test/Spec/Keystore.hs
+++ b/test/unit/Test/Spec/Keystore.hs
@@ -19,7 +19,9 @@ import           Test.QuickCheck.Monadic (forAllM, monadicIO, pick, run)
 import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, hash, safeKeyGen)
 
-import           Cardano.Wallet.Kernel.DB.HdWallet (HdRootId, eskToHdRootId)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
+                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdWallet ()
 import           Cardano.Wallet.Kernel.Keystore (DeletePolicy (..), Keystore)
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 
@@ -38,7 +40,7 @@ genKeypair :: NetworkMagic
                   )
 genKeypair nm = do
     (_, esk) <- arbitrary >>= safeKeyGen
-    return $ bimap STB STB (eskToHdRootId nm $ esk, esk)
+    return $ bimap STB STB (mkHdRootIdForFOWallet nm esk, esk)
 
 genKeys :: NetworkMagic
         -> Gen ( ShowThroughBuild HdRootId

--- a/test/unit/Test/Spec/NewPayment.hs
+++ b/test/unit/Test/Spec/NewPayment.hs
@@ -41,8 +41,7 @@ import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
                      (CoinSelectionOptions (..), ExpenseRegulation (..),
                      InputGrouping (..), newOptions)
 import           Cardano.Wallet.Kernel.DB.AcidState
-import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
-                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
                      HasSpendingPassword (..), HdAccountId (..),
                      HdAccountIx (..), HdAddressIx (..), WalletName (..),
@@ -89,7 +88,7 @@ prepareFixtures :: NetworkMagic
                 -> Fixture.GenActiveWalletFixture Fixture
 prepareFixtures nm initialBalance toPay = do
     let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
-    let newRootId = mkHdRootIdForFOWallet nm esk
+    let newRootId = eskToHdRootId nm esk
     now <- getCurrentTimestamp
     newRoot <- initHdRoot <$> pure newRootId
                           <*> pure (WalletName "A wallet")

--- a/test/unit/Test/Spec/Submission.hs
+++ b/test/unit/Test/Spec/Submission.hs
@@ -7,8 +7,7 @@ module Test.Spec.Submission (
 
 import           Universum hiding (elems)
 
-import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
-                     mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId (..),
                      HdAccountIx (..))
 import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
@@ -65,7 +64,7 @@ myAccountId = HdAccountId {
     }
     where
         myHdRootId :: HdRootId
-        myHdRootId = (mkHdRootIdForFOWallet NetworkMainOrStage) .
+        myHdRootId = (eskToHdRootId NetworkMainOrStage) .
                                snd .
                                safeDeterministicKeyGen (BS.pack (replicate 32 0)) $ mempty
 

--- a/test/unit/Test/Spec/Submission.hs
+++ b/test/unit/Test/Spec/Submission.hs
@@ -7,8 +7,10 @@ module Test.Spec.Submission (
 
 import           Universum hiding (elems)
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId,
+                     mkHdRootIdForFOWallet)
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId (..),
-                     HdAccountIx (..), HdRootId (..), eskToHdRootId)
+                     HdAccountIx (..))
 import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
 import qualified Cardano.Wallet.Kernel.DB.Spec.Pending as Pending
 import           Cardano.Wallet.Kernel.Submission
@@ -63,7 +65,7 @@ myAccountId = HdAccountId {
     }
     where
         myHdRootId :: HdRootId
-        myHdRootId = (eskToHdRootId NetworkMainOrStage) .
+        myHdRootId = (mkHdRootIdForFOWallet NetworkMainOrStage) .
                                snd .
                                safeDeterministicKeyGen (BS.pack (replicate 32 0)) $ mempty
 

--- a/test/unit/Test/Spec/Wallets.hs
+++ b/test/unit/Test/Spec/Wallets.hs
@@ -82,11 +82,8 @@ prepareFixtures = do
              Right v1Wallet -> do
                  let (V1.WalletId wId) = V1.walId v1Wallet
                  case decodeHdRootId wId of
-                      Left e -> error $  "Error decoding HdRootId "
-                                      <> show wId
-                                      <> ": "
-                                      <> show e
-                      Right rootId -> do
+                      Nothing -> error $ "Error decoding HdRootId " <> show wId
+                      Just rootId -> do
                           return (Fixture spendingPassword v1Wallet rootId)
 
 -- | A 'Fixture' where we already have a new 'Wallet' in scope.

--- a/test/unit/Test/Spec/Wallets.hs
+++ b/test/unit/Test/Spec/Wallets.hs
@@ -16,19 +16,17 @@ import           Test.QuickCheck.Monadic (PropertyM, monadicIO, pick)
 import           Data.Coerce (coerce)
 import           Formatting (build, formatToString)
 
-import           Pos.Core (decodeTextAddress)
 import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic, emptyPassphrase, hash)
 import           Pos.Crypto.HD (firstHardened)
 
 import qualified Cardano.Mnemonic as Mnemonic
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, decodeHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
-                     HdRootId (..), UnknownHdRoot (..), WalletName (..),
-                     hdRootId)
+                     UnknownHdRoot (..), WalletName (..), hdRootId)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create
                      (CreateHdRootError (..))
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import qualified Cardano.Wallet.Kernel.Internal as Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
@@ -83,13 +81,12 @@ prepareFixtures = do
              Left e         -> error (show e)
              Right v1Wallet -> do
                  let (V1.WalletId wId) = V1.walId v1Wallet
-                 case decodeTextAddress wId of
-                      Left e -> error $  "Error decoding the input Address "
+                 case decodeHdRootId wId of
+                      Left e -> error $  "Error decoding HdRootId "
                                       <> show wId
                                       <> ": "
                                       <> show e
-                      Right rootAddr -> do
-                          let rootId = HdRootId . InDb $ rootAddr
+                      Right rootId -> do
                           return (Fixture spendingPassword v1Wallet rootId)
 
 -- | A 'Fixture' where we already have a new 'Wallet' in scope.

--- a/test/unit/Util/Prefiltering.hs
+++ b/test/unit/Util/Prefiltering.hs
@@ -6,8 +6,9 @@ import           Universum
 
 import qualified Data.Map.Strict as Map
 
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId, HdAddress,
-                     HdRootId, hdAddressId, hdAddressIdParent, isOurs)
+                     hdAddressId, hdAddressIdParent, isOurs)
 import           Pos.Chain.Txp (TxOut (..), TxOutAux (..), Utxo)
 import           Pos.Crypto (EncryptedSecretKey)
 

--- a/test/unit/Wallet/Inductive/Cardano.hs
+++ b/test/unit/Wallet/Inductive/Cardano.hs
@@ -35,6 +35,7 @@ import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import qualified Cardano.Wallet.Kernel.BListener as Kernel
 import qualified Cardano.Wallet.Kernel.DB.AcidState as DB
 import qualified Cardano.Wallet.Kernel.DB.BlockContext as DB
+import           Cardano.Wallet.Kernel.DB.HdRootId (mkHdRootIdForFOWallet)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
 import qualified Cardano.Wallet.Kernel.DB.Resolved as DB
@@ -227,7 +228,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
                 -> Utxo
                 -> TranslateT EquivalenceViolation m HD.HdAccountId
     walletBootT ctxt utxo = do
-        let newRootId = HD.eskToHdRootId nm esk
+        let newRootId = mkHdRootIdForFOWallet nm esk
         let (Just defaultAddress) = Kernel.newHdAddress nm
                                                         esk
                                                         emptyPassphrase
@@ -260,7 +261,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
 
             utxoByAccount = prefilterUtxo rootId esk utxo
             accountIds    = Map.keys utxoByAccount
-            rootId        = HD.eskToHdRootId nm esk
+            rootId        = mkHdRootIdForFOWallet nm esk
 
             createWalletErr e =
                 error $ "ERROR: could not create the HdWallet due to " <> show e

--- a/test/unit/Wallet/Inductive/Cardano.hs
+++ b/test/unit/Wallet/Inductive/Cardano.hs
@@ -35,7 +35,7 @@ import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import qualified Cardano.Wallet.Kernel.BListener as Kernel
 import qualified Cardano.Wallet.Kernel.DB.AcidState as DB
 import qualified Cardano.Wallet.Kernel.DB.BlockContext as DB
-import           Cardano.Wallet.Kernel.DB.HdRootId (mkHdRootIdForFOWallet)
+import           Cardano.Wallet.Kernel.DB.HdRootId (eskToHdRootId)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
 import qualified Cardano.Wallet.Kernel.DB.Resolved as DB
@@ -228,7 +228,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
                 -> Utxo
                 -> TranslateT EquivalenceViolation m HD.HdAccountId
     walletBootT ctxt utxo = do
-        let newRootId = mkHdRootIdForFOWallet nm esk
+        let newRootId = eskToHdRootId nm esk
         let (Just defaultAddress) = Kernel.newHdAddress nm
                                                         esk
                                                         emptyPassphrase
@@ -261,7 +261,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
 
             utxoByAccount = prefilterUtxo rootId esk utxo
             accountIds    = Map.keys utxoByAccount
-            rootId        = mkHdRootIdForFOWallet nm esk
+            rootId        = eskToHdRootId nm esk
 
             createWalletErr e =
                 error $ "ERROR: could not create the HdWallet due to " <> show e


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#231</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `HdRootId` is an opaque type with `Text` inside.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

`HdRootId` now is a unified identifier for wallets (both FO and EO ones).
Technically it contains a text, but actually it contains one from two options:

1. for FO-wallets - `Core.Address` made from wallet's root public key, in Base58-format.
2. for EO-wallets - `UUID`, in Base58-format.

Please note that using `Core.Address` as wallet's identifier isn't a good decision, but since exchanges and users may have wallets' ids stored on their side we have to keep backward-compatibility for existing ids.