### PR TITLE
Golden Tests for Addresses à la BIP-44

### DIFF
--- a/cardano-sl.yaml
+++ b/cardano-sl.yaml
@@ -33,7 +33,7 @@ packages:
   commit: 93f2246c54436e7f98cc363b4e0f8f1cb5e78717
 
 - git: https://github.com/input-output-hk/cardano-crypto
-  commit: 59eb60b3a227c615736db9bb1609fd5c20109098
+  commit: 45e1a0eafac774c109704be44ca06fd8cae193ba
 
 - git: https://github.com/andrewthad/haskell-ip
   commit: 9bb453139aa82cc973125091800422a523e1eb8f

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -440,6 +440,7 @@ test-suite unit
       Arbitrary
       Golden.APILayout
       Golden.APIV1Types
+      Golden.Ed25519Addresses
       Golden.WalletError
       Test.Infrastructure.Generator
       Test.Infrastructure.Genesis

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/input-output-hk/cardano-sl
-  commit: 3de0352ef5b6326fa97d1918033a7194cf8d1cb7
+  commit: d705192d962fbe2ce4db8faf748b93666b35ad7b
   subdirs:
     - acid-state-exts
     - binary

--- a/test/unit/Golden/Ed25519Addresses.hs
+++ b/test/unit/Golden/Ed25519Addresses.hs
@@ -1,0 +1,197 @@
+module Golden.Ed25519Addresses
+    ( spec
+    ) where
+
+import           Universum hiding (pretty)
+
+import           Crypto.Encoding.BIP39 (ConsistentEntropy, EntropySize)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import           Test.Hspec (Spec, describe, it, shouldBe)
+
+import           Cardano.Mnemonic (Mnemonic, mkMnemonic)
+import           Cardano.Wallet.Kernel.Ed25519Bip44 (ChangeChain (..),
+                     deriveAddressKeyPair, genEncryptedSecretKey,
+                     isInternalChange)
+import           Pos.Core (Address)
+import           Pos.Core.Common (IsBootstrapEraAddr (..), decodeTextAddress,
+                     makePubKeyAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
+
+
+data TestVector = forall n. KnownNat n => TestVector
+    { _address
+        :: Address -- | Corresponding Cardano Address
+    , _accountIx
+        :: Word32 -- | Account index, hardened
+    , _changeChain
+        :: ChangeChain -- | Whether this is a change address or not
+    , _addressIx
+        :: Word32 -- | Address index, non-hardened
+    , _mnemonic
+        :: Mnemonic n -- | @n@ mnemonic words
+    , _mnemonicPassphrase
+        :: ByteString -- | A optional passphrase for mnemonic protection.
+    }
+
+spec :: Spec
+spec = do
+    describe "Ed25519 Addresses - Golden Tests" $ forM_ tests
+        $ \vec@(TestVector addr accIx change addrIx mw pw) -> it (titleize vec) $ do
+            let rootPassphrase = mempty
+            let esk = genEncryptedSecretKey (mw, pw) rootPassphrase
+            let pubKey = fst <$> deriveAddressKeyPair rootPassphrase esk accIx change addrIx
+            let addr' = makePubKeyAddress NetworkMainOrStage (IsBootstrapEraAddr True) <$> pubKey
+            addr' `shouldBe` (Just addr)
+  where
+    tests :: [TestVector]
+    tests =
+        [ TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZ1DYmhvpJWtVkMUbypPVkCVjQLNJeKRRG4LJ64dqTSRpWqzLH"
+            , _accountIx = 0x80000000
+            , _changeChain = ExternalChain
+            , _addressIx = 0x00000000
+            , _mnemonic = unsafeMkMnemonic @24
+                [ "process", "sauce", "ahead"
+                , "chase", "away", "ability"
+                , "odor", "excuse", "immune"
+                , "local", "climb", "wrestle"
+                , "vanish", "annual", "mimic"
+                , "square", "light", "corn"
+                , "dance", "fun", "april"
+                , "rail", "view", "certain"
+                ]
+            , _mnemonicPassphrase = "Cardano the cardano that cardano!"
+            }
+
+        , TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZ7ZyqyuDKkCnjrRjTY1vMJ8353gD7XWrUYufpVwEPhKwseVvf"
+            , _accountIx = 0x80000000
+            , _changeChain = ExternalChain
+            , _addressIx = 0x0000000E
+            , _mnemonic = unsafeMkMnemonic @24
+                [ "process", "sauce", "ahead"
+                , "chase", "away", "ability"
+                , "odor", "excuse", "immune"
+                , "local", "climb", "wrestle"
+                , "vanish", "annual", "mimic"
+                , "square", "light", "corn"
+                , "dance", "fun", "april"
+                , "rail", "view", "certain"
+                ]
+            , _mnemonicPassphrase = "Cardano the cardano that cardano!"
+            }
+
+        , TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZLSqQN7XNJRMJ6yHWdfFLaQgPPYgyJKrJnCVnRtbfw6EHRv1D"
+            , _accountIx = 0x8000000E
+            , _changeChain = InternalChain
+            , _addressIx = 0x0000002A
+            , _mnemonic = unsafeMkMnemonic @24
+                [ "process", "sauce", "ahead"
+                , "chase", "away", "ability"
+                , "odor", "excuse", "immune"
+                , "local", "climb", "wrestle"
+                , "vanish", "annual", "mimic"
+                , "square", "light", "corn"
+                , "dance", "fun", "april"
+                , "rail", "view", "certain"
+                ]
+            , _mnemonicPassphrase = "Cardano the cardano that cardano!"
+            }
+
+        , TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZGQVrA6qKreDzdtYxcWMMrpTFYCpFcuJfhJBEfoeiuW4MtaXZ"
+            , _accountIx = 0x80000000
+            , _changeChain = ExternalChain
+            , _addressIx = 0x00000000
+            , _mnemonic = unsafeMkMnemonic @15
+                [ "cruise", "legend", "nasty"
+                , "impose", "desk", "motion"
+                , "pistol", "rely", "camp"
+                , "journey", "drill", "spirit"
+                , "among", "basic", "frequent"
+                ]
+            , _mnemonicPassphrase = mempty
+            }
+
+        , TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZDLWQQEBR1UW7HeXJVaqUnuw8DUFu52TDWCJbxbkCyQYyxckP"
+            , _accountIx = 0x80000000
+            , _changeChain = ExternalChain
+            , _addressIx = 0x0000000E
+            , _mnemonic = unsafeMkMnemonic @15
+                [ "cruise", "legend", "nasty"
+                , "impose", "desk", "motion"
+                , "pistol", "rely", "camp"
+                , "journey", "drill", "spirit"
+                , "among", "basic", "frequent"
+                ]
+            , _mnemonicPassphrase = mempty
+            }
+
+        , TestVector
+            { _address = unsafeMkAddress "Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi"
+            , _accountIx = 0x8000000E
+            , _changeChain = InternalChain
+            , _addressIx = 0x0000002A
+            , _mnemonic = unsafeMkMnemonic @15
+                [ "cruise", "legend", "nasty"
+                , "impose", "desk", "motion"
+                , "pistol", "rely", "camp"
+                , "journey", "drill", "spirit"
+                , "among", "basic", "frequent"
+                ]
+            , _mnemonicPassphrase = mempty
+            }
+        ]
+
+
+--
+-- Internals
+--
+
+class UnsafeMkMnemonic mw where
+    unsafeMkMnemonic
+        :: (ConsistentEntropy n mw csz, EntropySize mw ~ n)
+        => [Text]
+        -> Mnemonic mw
+    unsafeMkMnemonic ws =
+        case mkMnemonic ws of
+            Left e ->
+                error $
+                    "Golden.Ed25519Addresses: failed to create mnemonic for the \
+                    \test vector using the given words: " <> show ws
+                    <> "\n" <> show e
+            Right m -> m
+instance UnsafeMkMnemonic 24
+instance UnsafeMkMnemonic 15
+
+unsafeMkAddress
+    :: Text
+    -> Address
+unsafeMkAddress txt =
+    case decodeTextAddress txt of
+        Left e ->
+            error $
+                "Golden.Ed25519Addresses: failed to create address for the \
+                \test vector using the given base58 text: " <> show txt
+                <> "\n" <> show e
+        Right a -> a
+
+titleize
+    :: TestVector
+    -> String
+titleize (TestVector _ accIx change addrIx (mw :: Mnemonic n) pw) =
+    mwS <> " (n = " <> nS <> ") " <> pwS <> " " <> accIxS <> "/" <> changeS <> "/" <> addrIxS
+  where
+    ellipse n bs = BS.take n bs <> "..." <> BS.drop (BS.length bs - n) bs
+    nS = show $ natVal $ Proxy @n
+    mwS = T.unpack $ T.decodeUtf8 $ ellipse 26 (BL.toStrict $ Aeson.encode mw)
+    pwS = if null pw then "no passphrase  " else "with passphrase"
+    accIxS = show (accIx - 0x80000000) <> "'"
+    changeS = if isInternalChange change then "1" else "0"
+    addrIxS = show addrIx

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -18,6 +18,7 @@ import qualified API.RequestSpec as ReqSpec
 import qualified API.SwaggerSpec as Swagger
 import qualified Golden.APILayout
 import qualified Golden.APIV1Types
+import qualified Golden.Ed25519Addresses
 import qualified Golden.WalletError
 import qualified Test.Spec.Accounts
 import qualified Test.Spec.Addresses
@@ -46,7 +47,9 @@ main = do
         [ Golden.APIV1Types.tests
         , Golden.WalletError.tests
         ]
-    hspec Golden.APILayout.spec
+    hspec $ do
+        Golden.APILayout.spec
+        Golden.Ed25519Addresses.spec
 
     -- API Specs
     hspec $ do


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#195</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have implemented a method to generate `XPrv` / `EncryptedSecretKey` compatible with the new derivation scheme à la BIP-44 (& Icarus/Yoroi wallets)
- [x] I have added golden tests which illustrates and compare this generation and derivation of child keys with Yoroi / Icarus wallets.

# Comments

<!-- Additional comments or screenshots to attach if any -->

That was a bit confusing initially but after a chat with the Rust team, we discovered that root seed in `cardano-cli` (and therefore, Yoroi, Icarus) were generated differently from what we use to do. So, having the right derivation scheme and approach isn't sufficient; if, given the same mnemonics and passphrase, we do not generate the same root seed, all the rest is kinda pointless.

This PR fixes that :+1:

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
