### PR TITLE
[BIP44-103] Track EOS wallets

### DIFF
--- a/src/Cardano/Wallet/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/Kernel/Addresses.hs
@@ -25,9 +25,9 @@ import           Cardano.Wallet.Kernel.DB.AcidState (CreateHdAddress (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId,
                      HdAccountIx (..), HdAddress, HdAddressId (..),
                      HdAddressIx (..), hdAccountIdIx, hdAccountIdParent,
-                     hdAddressIdIx)
+                     hdAddressIdIx, initHdAddress)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create
-                     (CreateHdAddressError (..), initHdAddress)
+                     (CreateHdAddressError (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
 import           Cardano.Wallet.Kernel.Internal (PassiveWallet, walletKeystore,

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -13,7 +13,6 @@ module Cardano.Wallet.Kernel.DB.HdWallet.Create (
     -- * Initial values
   , initHdRoot
   , initHdAccount
-  , initHdAddress
   ) where
 
 import           Universum
@@ -160,23 +159,6 @@ initHdAccount accountId st = HdAccount {
   where
     defName = AccountName $ sformat ("Account: " % build)
                                     (accountId ^. hdAccountIdIx)
-
--- | New address in the specified account
---
--- Since the DB does not contain the private key of the wallet, we cannot
--- do the actual address derivation here; this will be the responsibility of
--- the caller (which will require the use of the spending password, if
--- one exists).
---
--- Similarly, it will be the responsibility of the caller to pick a random
--- address index, as we do not have access to a random number generator here.
-initHdAddress :: HdAddressId
-              -> Core.Address
-              -> HdAddress
-initHdAddress addrId address = HdAddress {
-      _hdAddressId      = addrId
-    , _hdAddressAddress = InDb address
-    }
 
 {-------------------------------------------------------------------------------
   Pretty printing

--- a/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/src/Cardano/Wallet/Kernel/Restore.hs
@@ -38,7 +38,6 @@ import           Cardano.Wallet.Kernel.DB.BlockContext
 import qualified Cardano.Wallet.Kernel.DB.HdRootId as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (CreateHdRootError)
-import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
 import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock,
                      resolvedToTxMetas)


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-wallet/issues/239

# Overview

When the wallet applies blocks it prefilters for "our" addresses and in this way tracks the utxo and balance of a wallet. 

# Development plan

To enable tracking of EOS wallets

- [x] Implement ISOurs prefiltering for Hd Sequential wallets
- [ ] Persist EOS wallet Account PKs and AccountPools
- [ ] On wallet startup, recover EOS wallet AccountPKs and use track the EOS accounts during applyBlock
- [ ] test EOS tracking
 
# Comments

- This does not include extending Restoration of EOS wallet

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->