### PR TITLE
Additional fields for EOS-stuff in 'HdWallets'.

### DIFF
--- a/src/Cardano/Wallet/Kernel/AddressPoolGap.hs
+++ b/src/Cardano/Wallet/Kernel/AddressPoolGap.hs
@@ -14,6 +14,7 @@ import           Universum
 import qualified Data.Aeson.Options as Aeson
 import           Data.Aeson.TH
 import           Data.Default (Default (..))
+import           Data.SafeCopy (base, deriveSafeCopy)
 import           Data.Swagger (ToSchema (..), defaultSchemaOptions,
                      genericDeclareNamedSchema)
 import           Data.Text.Read (decimal)
@@ -77,3 +78,5 @@ mkAddressPoolGap gap
     | otherwise = Left $ GapOutOfRange gap
 
 deriveJSON Aeson.defaultOptions ''AddressPoolGap
+
+deriveSafeCopy 1 'base ''AddressPoolGap

--- a/src/Cardano/Wallet/Kernel/DB/EosHdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/EosHdWallet.hs
@@ -93,7 +93,6 @@ makeLenses ''EosHdRoot
 makeLenses ''EosHdAccount
 makeLenses ''EosHdWallets
 
-deriveSafeCopy 1 'base ''AddressPoolGap
 deriveSafeCopy 1 'base ''EosHdRoot
 deriveSafeCopy 1 'base ''EosHdAccount
 deriveSafeCopy 1 'base ''EosHdWallets


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#231</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added new `IxSet` for `AddressPoolGap`.
- [x] I have added new `IxSet` for accounts' public keys.

# Comments

<!-- Additional comments or screenshots to attach if any -->

We have an opaque `HdRootId` now, so it's possible to use existing type hierarchy (`HdRoot`, `HdAccount` and `HdAddress`) to store EOS-wallets' stuff (common for both types of wallets). But since we have a _specific_ EOS-stuff, we introduce two new fields in `HdWallets` to store it:

1. `IxSet` for `HdRootAddressPoolGap` (one value for each EOS-wallet).
2. `IxSet` for `HdAccountPublicKey` (one value for each account in EOS-wallet).

SInce it's `IxSet`, we'll be able to introduce (in the next PR) getters we need:

```
addressPoolGap :: HdRootId -> Maybe AddressPoolGap

accountPublicKey :: HdAccountId -> Maybe PublicKey
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->