### PR TITLE
Allow AddressPool to be created from an initial list of addresses

### DIFF
--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -578,9 +578,9 @@ instance IsOurs (Map HdAccountId (AddressPool Core.Address)) where
                     (Nothing, _) -> Nothing
                     (Just (_, ix), pool') -> (Just (mkHdAddress accId ix, pool'))
 
-            mkHdAddress :: HdAccountId -> Word -> HdAddress
+            mkHdAddress :: HdAccountId -> Word32 -> HdAddress
             mkHdAddress accId_ ix_
-                = initHdAddress (HdAddressId accId_ (HdAddressIx (fromIntegral ix_))) addr
+                = initHdAddress (HdAddressId accId_ (HdAddressIx ix_)) addr
 
 {-------------------------------------------------------------------------------
   Unknown identifiers

--- a/test/unit/Test/Spec/AddressPool.hs
+++ b/test/unit/Test/Spec/AddressPool.hs
@@ -3,24 +3,58 @@ module Test.Spec.AddressPool (spec) where
 import           Universum
 
 import           Cardano.Wallet.Kernel.AddressPool (AddressPool,
+                     ErrAddressPoolInvalid (..), emptyAddressPool,
                      getAddressPoolGap, getAddressPoolSize, initAddressPool,
-                     lookupAddressPool)
+                     lookupAddressPool, verifyPool)
 import           Cardano.Wallet.Kernel.AddressPoolGap (AddressPoolGap)
 
 import           Test.Hspec (Spec, describe, it)
 import           Test.Pos.Core.Arbitrary ()
-import           Test.QuickCheck (Property, label, property, (.&&.), (===))
+import           Test.QuickCheck (Arbitrary (..), Property, choose, conjoin,
+                     label, property, (===))
 
 spec :: Spec
 spec = describe "AddressPool" $ do
+    it "initAddressPool" $ property prop_initAddressPool
+    it "emptyAddressPool" $ property prop_emptyAddressPool
     it "lookupAddressPool" $ property prop_lookupAddressPool
+
+prop_initAddressPool
+    :: (Parameters Word32)
+    -> Maybe ErrAddressPoolInvalid
+    -> Property
+prop_initAddressPool (Parameters gap addrs0) = \case
+    Nothing -> label "valid params" $
+        void (initAddressPool gap identity addrs0) === Right ()
+    Just e -> label ("invalid params: " <> show e) $
+        let
+            -- NOTE Manunally craft a faulty list of addresses
+            g = fromIntegral gap
+            addrs0' = case e of
+                ErrIndexesAreNotSequential ->
+                    replace (g - 1) (9999, 9999) addrs0
+                ErrNotEnoughAddresses ->
+                    take (g - 1) addrs0
+        in
+            void (initAddressPool gap identity addrs0') === Left e
+  where
+    replace i x xs =
+        let front = take (i - 1) xs; back = drop i xs
+        in  front ++ [x] ++ back
+
+prop_emptyAddressPool
+    :: AddressPoolGap
+    -> Property
+prop_emptyAddressPool gap =
+    let pool = emptyAddressPool gap identity  in pool `seq` property True
 
 -- | It proves that pool extension works as expected.
 prop_lookupAddressPool
-    :: (AddressPoolGap, Int)
+    :: (Parameters Word32, Int)
     -> Property
-prop_lookupAddressPool (gap, addr) = do
-    prop_lookupAddressPool' (initAddressPool gap identity, fromIntegral addr)
+prop_lookupAddressPool (Parameters gap addrs0, addr) =
+    let Right pool = initAddressPool gap identity addrs0
+    in  prop_lookupAddressPool' (pool, fromIntegral addr)
 
 prop_lookupAddressPool'
     :: (Show address, Ord address, Eq address)
@@ -28,11 +62,38 @@ prop_lookupAddressPool'
     -> Property
 prop_lookupAddressPool' (pool, addr) =
     case lookupAddressPool addr pool of
-        (Nothing, pool') -> label "hit outside pool" $
-            on (===) getAddressPoolSize pool pool' .&&.
-            on (===) getAddressPoolGap  pool pool'
+        (Nothing, pool') -> label "hit outside pool" $ conjoin
+            [ void (verifyPool pool') === Right ()
+            , on (===) getAddressPoolSize pool pool'
+            , on (===) getAddressPoolGap  pool pool'
+            ]
         (Just (addr', _), pool') -> label "hit within pool" $
             let k = on (-) getAddressPoolSize pool' pool
-            in  addr' === addr .&&.
-                on (===) getAddressPoolGap pool pool' .&&.
-                property (k >= 0 && k <= fromIntegral (getAddressPoolGap pool))
+            in conjoin
+                [ void (verifyPool pool') === Right ()
+                , addr' === addr
+                , on (===) getAddressPoolGap pool pool'
+                , property (k >= 0 && k <= fromIntegral (getAddressPoolGap pool))
+                ]
+
+
+{-------------------------------------------------------------------------------
+  Utils
+-------------------------------------------------------------------------------}
+
+data Parameters address = Parameters
+    { pGap              :: AddressPoolGap
+    , pInitialAddresses :: [(address, Word32)]
+    }
+    deriving Show
+
+instance Arbitrary (Parameters Word32) where
+    arbitrary = do
+        gap <- arbitrary
+        n <- choose (fromIntegral gap, 5 * (fromIntegral gap))
+        return $ Parameters gap (zip [0..n] [0..])
+    shrink (Parameters gap xs) = Parameters gap
+        <$> filter ((>= fromIntegral gap) . length)
+                [ take (length xs `div` 2) xs
+                , take (length xs - 1) xs
+                ]


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#231</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have extended the constructor of `AddressPool` to also accept an initial list of addresses + indexes
- [x] I have extended the test suite to reflect that change and tests the behavior when various initial (valid) list of addresses are given
- [x] I have provided an accessor to retrieve all known addresses from the pool gap (and allow future serialization / persistence of those addresses)

# Comments

<!-- Additional comments or screenshots to attach if any -->

This is for allowing serialization of the underlying pool. In theory,
we should never hit the 'Left' side of the constructor because given
addresses are generated only using the pool and nothing more.


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
