### PR TITLE
API changes for EOS-wallets creation: accounts public keys with indexes.

### DIFF
--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -241,7 +241,7 @@ createHdWallet pw mnemonic spendingPassword assuranceLevel walletName = do
 
 -- | Creates a new EOS HD 'Wallet'.
 createEosHdWallet :: PassiveWallet
-                  -> [PublicKey]
+                  -> [(PublicKey, Word32)]
                   -- ^ External wallet's accounts public keys.
                   -> AddressPoolGap
                   -- ^ Address pool gap for this wallet.
@@ -253,11 +253,13 @@ createEosHdWallet :: PassiveWallet
                   -> WalletName
                   -- ^ The name for this wallet.
                   -> IO (Either CreateEosWalletError EosHdRoot)
-createEosHdWallet pw accountsPKs addressPoolGap assuranceLevel walletName = do
+createEosHdWallet pw accountsPKsWithIxs addressPoolGap assuranceLevel walletName = do
     -- Here, we review the definition of a wallet down to a list of account public keys with
     -- no relationship whatsoever from the wallet's point of view. New addresses can be derived
     -- for each account at will and discovered using the address pool discovery algorithm
     -- described in BIP-44. Public keys are managed and provided from an external sources.
+    -- TODO: Temporary solution, will be fixed soon, see #231.
+    let accountsPKs = map fst accountsPKsWithIxs
     newEosWalletId <- genEosWalletId
     let newEosRoot = EosHdRoot newEosWalletId
                                walletName

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -153,7 +153,9 @@ createEosWallet :: MonadIO m
                 -> V1.NewEosWallet
                 -> m (Either CreateEosWalletError V1.EosWallet)
 createEosWallet wallet newEosWalletRequest = runExceptT $ do
-    let accountsPublicKeys = V1.neweoswalAccountsPublicKeys newEosWalletRequest
+    let accountsPublicKeysWithIxs =
+            map (\(V1.AccountPublicKeyWithIx pk ix) -> (pk, V1.getAccIndex ix)) $
+                V1.neweoswalAccounts newEosWalletRequest
         addressPoolGap = maybe (def :: AddressPoolGap) id $
             V1.neweoswalAddressPoolGap newEosWalletRequest
         name = V1.neweoswalName newEosWalletRequest
@@ -161,7 +163,7 @@ createEosWallet wallet newEosWalletRequest = runExceptT $ do
     _ <- withExceptT CreateEosWalletError $ ExceptT $ liftIO $
         Kernel.createEosHdWallet
             wallet
-            accountsPublicKeys
+            accountsPublicKeysWithIxs
             addressPoolGap
             (fromAssuranceLevel assuranceLevel)
             (HD.WalletName name)


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#231</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] During EOS-wallet creation not only account's public key is provided, but its index as well.


# Comments

<!-- Additional comments or screenshots to attach if any -->

Since we receive accounts' public keys as they are, we need their indexes as well.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
