### PR TITLE
Batch Import for Addresses

### DIFF
--- a/src/Cardano/Wallet/API/V1/Addresses.hs
+++ b/src/Cardano/Wallet/API/V1/Addresses.hs
@@ -19,4 +19,8 @@ type API = Tags '["Addresses"] :>
       :<|> "addresses" :> Capture "address" Text
                        :> Summary "Returns interesting information about an address, if available and valid."
                        :> Get '[ValidJSON] (APIResponse WalletAddress)
+      :<|> "wallets" :> CaptureWalletId :> "accounts" :> CaptureAccountId :> "addresses"
+        :> Summary "Batch import existing addresses"
+        :> ReqBody '[ValidJSON] [WalAddress]
+        :> Post '[ValidJSON] (APIResponse (BatchImportResult WalAddress))
       )

--- a/src/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/src/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -20,6 +20,7 @@ handlers :: PassiveWalletLayer IO -> ServerT Addresses.API Handler
 handlers w =  listAddresses w
          :<|> newAddress w
          :<|> getAddress w
+         :<|> importAddresses w
 
 listAddresses :: PassiveWalletLayer IO
               -> RequestParams -> Handler (APIResponse [WalletAddress])
@@ -49,3 +50,16 @@ getAddress pwl addressRaw = do
     case res of
          Left err   -> throwM err
          Right addr -> return $ single addr
+
+
+importAddresses
+    :: PassiveWalletLayer IO
+    -> WalletId
+    -> AccountIndex
+    -> [WalAddress]
+    -> Handler (APIResponse (BatchImportResult WalAddress))
+importAddresses pwl walId accIx addrs = do
+    res <- liftIO $ WalletLayer.importAddresses pwl walId accIx addrs
+    case res of
+        Left err   -> throwM err
+        Right res' -> return $ single res'

--- a/src/Cardano/Wallet/Client.hs
+++ b/src/Cardano/Wallet/Client.hs
@@ -76,6 +76,11 @@ data WalletClient m
          :: NewAddress -> Resp m WalletAddress
     , getAddress
          :: Text -> Resp m WalletAddress
+    , importAddresses
+        :: WalletId
+        -> AccountIndex
+        -> [WalAddress]
+        -> Resp m (BatchImportResult WalAddress)
     -- wallets endpoints
     , postWallet
          :: New Wallet -> Resp m Wallet
@@ -232,6 +237,8 @@ natMapClient phi f wc = WalletClient
         f . phi . postAddress wc
     , getAddress =
         f . phi . getAddress wc
+    , importAddresses =
+        \x y -> f . phi . importAddresses wc x y
     , postWallet =
         f . phi . postWallet wc
     , getWalletIndexFilterSorts =

--- a/src/Cardano/Wallet/Client/Http.hs
+++ b/src/Cardano/Wallet/Client/Http.hs
@@ -42,6 +42,8 @@ mkHttpClient baseUrl manager = WalletClient
         = run . postAddressR
     , getAddress
         = run . getAddressR
+    , importAddresses
+        = \x y -> run . importAddressesR x y
     -- wallets endpoints
     , postWallet
         = run . postWalletR
@@ -131,6 +133,7 @@ mkHttpClient baseUrl manager = WalletClient
     getAddressIndexR
         :<|> postAddressR
         :<|> getAddressR
+        :<|> importAddressesR
         = addressesAPI
 
     postWalletR

--- a/src/Cardano/Wallet/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/Kernel/Addresses.hs
@@ -1,14 +1,19 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Cardano.Wallet.Kernel.Addresses (
       createAddress
     , newHdAddress
+    , importAddresses
     -- * Errors
     , CreateAddressError(..)
+    , ImportAddressError(..)
     ) where
 
 import qualified Prelude
 import           Universum
 
 import           Control.Lens (to)
+import           Control.Monad.Except (throwError)
 import           Formatting (bprint, build, formatToString, (%))
 import qualified Formatting as F
 import qualified Formatting.Buildable
@@ -22,10 +27,11 @@ import           Pos.Crypto (EncryptedSecretKey, PassPhrase,
                      ShouldCheckPassphrase (..))
 
 import           Cardano.Wallet.Kernel.DB.AcidState (CreateHdAddress (..))
+import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId,
                      HdAccountIx (..), HdAddress, HdAddressId (..),
-                     HdAddressIx (..), hdAccountIdIx, hdAccountIdParent,
-                     hdAddressIdIx, initHdAddress)
+                     HdAddressIx (..), IsOurs (..), hdAccountIdIx,
+                     hdAccountIdParent, hdAddressIdIx, initHdAddress)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create
                      (CreateHdAddressError (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
@@ -178,3 +184,63 @@ newHdAddress nm esk spendingPassword accId hdAddressId =
     in case mbAddr of
          Nothing              -> Nothing
          Just (newAddress, _) -> Just $ initHdAddress hdAddressId newAddress
+
+
+data ImportAddressError
+    = ImportAddressKeystoreNotFound HdAccountId
+    -- ^ When trying to create the 'Address', the parent 'Account' was not there.
+    deriving Eq
+
+instance Arbitrary ImportAddressError where
+    arbitrary = oneof
+        [ ImportAddressKeystoreNotFound <$> arbitrary
+        ]
+
+instance Buildable ImportAddressError where
+    build = \case
+        ImportAddressKeystoreNotFound uAccount ->
+            bprint ("ImportAddressError" % F.build) uAccount
+
+instance Show ImportAddressError where
+    show = formatToString build
+
+
+-- | Import already existing addresses into the DB. A typical use-case for that
+-- is backend migration, where users (e.g. exchanges) want to import unused
+-- addresses they've generated in the past (and likely communicated to their
+-- users). Because Addresses in the old scheme are generated randomly, there's
+-- no guarantee that addresses would be generated in the same order on a new
+-- node (they better not actually!).
+importAddresses
+    :: HdAccountId
+    -- ^ An abstract notion of an 'Account' identifier
+    -> [Address]
+    -> PassiveWallet
+    -> IO (Either ImportAddressError [Either Address ()])
+importAddresses accId addrs pw = runExceptT $ do
+    let rootId = accId ^. hdAccountIdParent
+    esk <- lookupSecretKey rootId
+    lift $ forM addrs (flip importOneAddress [(rootId, esk)])
+  where
+    lookupSecretKey
+        :: HdRootId
+        -> ExceptT ImportAddressError IO EncryptedSecretKey
+    lookupSecretKey rootId = do
+        let nm = makeNetworkMagic (pw ^. walletProtocolMagic)
+        let keystore = pw ^. walletKeystore
+        lift (Keystore.lookup nm rootId keystore) >>= \case
+            Nothing  -> throwError (ImportAddressKeystoreNotFound accId)
+            Just esk -> return esk
+
+    importOneAddress
+        :: Address
+        -> [(HdRootId, EncryptedSecretKey)]
+        -> IO (Either Address ())
+    importOneAddress addr = evalStateT $ do
+        let updateLifted = fmap Just .  lift . update (pw ^. wallets)
+        res <- state (isOurs addr) >>= \case
+            Nothing     -> return Nothing
+            Just hdAddr -> updateLifted $ CreateHdAddress hdAddr
+        return $ case res of
+            Just (Right _) -> Right ()
+            _              -> Left addr

--- a/src/Cardano/Wallet/WalletLayer.hs
+++ b/src/Cardano/Wallet/WalletLayer.hs
@@ -17,6 +17,7 @@ module Cardano.Wallet.WalletLayer
     , RedeemAdaError(..)
     , CreateAddressError(..)
     , ValidateAddressError(..)
+    , ImportAddressError(..)
     , CreateAccountError(..)
     , GetAccountError(..)
     , GetAccountsError(..)
@@ -48,12 +49,12 @@ import           Cardano.Wallet.API.Request.Filter (FilterOperations (..))
 import           Cardano.Wallet.API.Request.Sort (SortOperations (..))
 import           Cardano.Wallet.API.Response (APIResponse, SliceOf (..))
 import           Cardano.Wallet.API.V1.Types (Account, AccountBalance,
-                     AccountIndex, AccountUpdate, EosWallet, NewAccount,
-                     NewAddress, NewEosWallet, NewWallet, PasswordUpdate,
-                     Payment, Redemption, SignedTransaction, SpendingPassword,
-                     Transaction, UnsignedTransaction, WalAddress, Wallet,
-                     WalletAddress, WalletId, WalletImport, WalletTimestamp,
-                     WalletTxId, WalletUpdate)
+                     AccountIndex, AccountUpdate, BatchImportResult, EosWallet,
+                     NewAccount, NewAddress, NewEosWallet, NewWallet,
+                     PasswordUpdate, Payment, Redemption, SignedTransaction,
+                     SpendingPassword, Transaction, UnsignedTransaction,
+                     WalAddress, Wallet, WalletAddress, WalletId, WalletImport,
+                     WalletTimestamp, WalletTxId, WalletUpdate)
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
@@ -262,6 +263,30 @@ instance Buildable ValidateAddressError where
     build (ValidateAddressDecodingFailed rawText) =
         bprint ("ValidateAddressDecodingFailed " % build) rawText
 
+data ImportAddressError =
+      ImportAddressError Kernel.ImportAddressError
+    | ImportAddressAddressDecodingFailed Text
+    -- ^ Decoding the input 'Text' as an 'Address' failed.
+    deriving Eq
+
+-- | Unsound show instance needed for the 'Exception' instance.
+instance Show ImportAddressError where
+    show = formatToString build
+
+instance Exception ImportAddressError
+
+instance Arbitrary ImportAddressError where
+    arbitrary = oneof [ ImportAddressError <$> arbitrary
+                      , pure (ImportAddressAddressDecodingFailed "Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxx")
+                      ]
+
+instance Buildable ImportAddressError where
+    build (ImportAddressError kernelError) =
+        bprint ("ImportAddressError " % build) kernelError
+    build (ImportAddressAddressDecodingFailed txt) =
+        bprint ("ImportAddressAddressDecodingFailed " % build) txt
+
+
 ------------------------------------------------------------
 -- Errors when dealing with Accounts
 ------------------------------------------------------------
@@ -465,6 +490,10 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , getAddresses         :: RequestParams -> m (SliceOf WalletAddress)
     , validateAddress      :: Text
                            -> m (Either ValidateAddressError WalletAddress)
+    , importAddresses      :: WalletId
+                           -> AccountIndex
+                           -> [WalAddress]
+                           -> m (Either ImportAddressError (BatchImportResult WalAddress))
 
     -- transactions
     , getTransactions      :: Maybe WalletId

--- a/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -120,6 +120,7 @@ bracketPassiveWallet pm mode logFunction keystore node fInjects f = do
         , updateAccount        = Accounts.updateAccount       w
         , deleteAccount        = Accounts.deleteAccount       w
         , createAddress        = Addresses.createAddress      w
+        , importAddresses      = Addresses.importAddresses    w
         , resetWalletState     = Internal.resetWalletState    w
         , importWallet         = Internal.importWallet        w
         , applyBlocks          = invokeIO . Actions.ApplyBlocks

--- a/test/unit/Golden/golden/api-layout.txt
+++ b/test/unit/Golden/golden/api-layout.txt
@@ -24,6 +24,12 @@
 │  ┆
 │  └─•
 └─ wallets/
+   ├─ <capture>/
+   │  └─ accounts/
+   │     └─ <capture>/
+   │        └─ addresses/
+   │           └─•
+   ┆
    ├─•
    ┆
    ├─•


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#258</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added an extra endpoint to import batch of addresses (used or unused)
- [ ] I have defined a `BatchImportResult` type to aggregate imported results (we care about failures, but not much about successes)
- [ ] I have implemented the import in a rather naive fashion adding addresses one-by-one.  

# Comments

<!-- Additional comments or screenshots to attach if any -->

The approach taken to implement the import may be rather inefficient. However, this endpoint will likely be used only once per exchange and need to get shipped ASAP. So performance is our least concern here. If it later becomes _a thing_; we may consider doing batch updates and provide the necessary tools out of our acid-state layer. I thought `AccountUpdate` were doing batch updates for addresses (since they do have a `addrs` field); Though, it boils down to a quick-n-dirty `mapM_ createAddress accountUpdateAddrs` :disappointed: 

Nothing has been tested yet. Integration tests are coming in a second PR later and may likely fix a bunch of stuff in the implementation. Who knows. At least, this can serve as a skeleton / foundation.

![image](https://user-images.githubusercontent.com/5680256/51737905-1918a080-208e-11e9-8897-5a93ea83cfc2.png)

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
