### PR TITLE
[BIP44-239] (WIP) Extend prefiltering to EOS wallets for ApplyBlock

### DIFF
--- a/src/Cardano/Wallet/Kernel/AddressPool.hs
+++ b/src/Cardano/Wallet/Kernel/AddressPool.hs
@@ -77,6 +77,12 @@ data ErrAddressPoolInvalid
     | ErrNotEnoughAddresses
     deriving (Eq, Show)
 
+instance Buildable ErrAddressPoolInvalid where
+    build ErrIndexesAreNotSequential =
+        bprint "ErrIndexesAreNotSequential"
+    build ErrNotEnoughAddresses =
+        bprint "ErrNotEnoughAddresses"
+
 instance Exception ErrAddressPoolInvalid
 
 instance Arbitrary ErrAddressPoolInvalid where

--- a/src/Cardano/Wallet/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/Kernel/Addresses.hs
@@ -20,6 +20,7 @@ import qualified Formatting.Buildable
 import           System.Random.MWC (GenIO, createSystemRandom, uniformR)
 
 import           Data.Acid (update)
+import qualified Data.Map.Strict as Map
 
 import           Pos.Core (Address, IsBootstrapEraAddr (..), deriveLvl2KeyPair)
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
@@ -220,7 +221,7 @@ importAddresses
 importAddresses accId addrs pw = runExceptT $ do
     let rootId = accId ^. hdAccountIdParent
     esk <- lookupSecretKey rootId
-    lift $ forM addrs (flip importOneAddress [(rootId, esk)])
+    lift $ forM addrs (flip importOneAddress (Map.singleton rootId esk))
   where
     lookupSecretKey
         :: HdRootId
@@ -234,7 +235,7 @@ importAddresses accId addrs pw = runExceptT $ do
 
     importOneAddress
         :: Address
-        -> [(HdRootId, EncryptedSecretKey)]
+        -> Map HdRootId EncryptedSecretKey
         -> IO (Either Address ())
     importOneAddress addr = evalStateT $ do
         let updateLifted = fmap Just .  lift . update (pw ^. wallets)

--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -66,14 +66,16 @@ import           Cardano.Wallet.WalletLayer.Kernel.Wallets
 type PrefilterResult = ((BlockContext, PrefilteredBlock), [TxMeta])
 
 -- | Prefilter a list of resolved blocks for all accounts in all wallets.
--- Since different types wallets have different prefiltering mechanisms, we need
--- to do prefiltering seperately for each type of wallet and then combine the results.
-prefilterBlocks :: PassiveWallet
-                -> [ResolvedBlock]
-                -> IO (Maybe [PrefilterResult])
+-- Since different types wallets have different prefiltering mechanisms,
+-- we need to do prefiltering seperately for each type of wallet and then
+-- combine the results.
+--
 -- Returns 'Nothing' if the prefiltering is irrelevant for this node, i.e.
 -- there are no user wallets stored, so we can avoid doing work
 -- (e.g. writing into the acid-state DB log) by skipping such block application).
+prefilterBlocks :: PassiveWallet
+                -> [ResolvedBlock]
+                -> IO (Maybe [PrefilterResult])
 prefilterBlocks _ [] = return Nothing
 prefilterBlocks pw bs = do
     db <- getWalletSnapshot pw

--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -51,7 +51,7 @@ import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.Prefiltering (PrefilteredBlock,
                      prefilterBlock)
 import           Cardano.Wallet.Kernel.Read (foreignPendingByAccount,
-                     getHdRndWallets, getHdSeqWallets, getWalletSnapshot)
+                     getHdRndWallets, getEosPools, getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Restore
 import qualified Cardano.Wallet.Kernel.Submission as Submission
 import           Cardano.Wallet.Kernel.Util.NonEmptyMap (NonEmptyMap)
@@ -81,7 +81,7 @@ prefilterBlocks pw bs = do
     db <- getWalletSnapshot pw
     let foreigns = fmap Pending.txIns . foreignPendingByAccount $ db
     hdRnds <- getHdRndWallets_ db
-    hdSeqs <- getHdSeqWallets db
+    hdSeqs <- getEosPools db
 
     listToMaybe' <$>
         ((<>) <$> prefilter foreigns hdRnds <*> prefilter foreigns hdSeqs)

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -101,6 +101,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet (
   , IsOurs(..)
     -- Address pool
   , mkAddressPool
+  , mkAddressPoolExisting
   ) where
 
 import           Universum hiding ((:|))
@@ -124,7 +125,8 @@ import qualified Pos.Crypto as Core
 
 import           Cardano.Wallet.API.V1.Types (WalAddress (..))
 import           Cardano.Wallet.Kernel.AddressPool (AddressPool,
-                     emptyAddressPool, lookupAddressPool)
+                     ErrAddressPoolInvalid(..),
+                     emptyAddressPool, initAddressPool, lookupAddressPool)
 import           Cardano.Wallet.Kernel.AddressPoolGap (AddressPoolGap)
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
@@ -576,10 +578,25 @@ mkAddressPool
     -> Core.PublicKey
     -> AddressPoolGap
     -> AddressPool Core.Address
-mkAddressPool mkAddress accPK gap = emptyAddressPool gap newAddress
-  where
-    newAddress :: Word32 -> Core.Address
-    newAddress addrIx = case deriveAddressPublicKey accPK ExternalChain addrIx of
+mkAddressPool mkAddress accPK gap
+    = emptyAddressPool gap (mkAddressBuilder mkAddress accPK)
+
+mkAddressPoolExisting
+    :: (Core.PublicKey -> Core.Address)
+    -> Core.PublicKey
+    -> AddressPoolGap
+    -> [(Core.Address, Word32)]
+    -> Either ErrAddressPoolInvalid (AddressPool Core.Address)
+mkAddressPoolExisting mkAddress accPK gap addrs
+    = initAddressPool gap (mkAddressBuilder mkAddress accPK) addrs
+
+mkAddressBuilder
+    :: (Core.PublicKey -> Core.Address)
+    -> Core.PublicKey
+    -> Word32
+    -> Core.Address
+mkAddressBuilder mkAddress accPK addrIx 
+    = case deriveAddressPublicKey accPK ExternalChain addrIx of
         Nothing     -> error "mkAddressPool: maximum number of addresses reached."
         Just addrPK -> mkAddress addrPK
 

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -533,9 +533,9 @@ hdAccountRestorationState a = case a ^. hdAccountState of
 -------------------------------------------------------------------------------}
 
 class IsOurs s where
-    -- For the given state, check whether an address is "ours"
+    -- | For the given state, check whether an address is "ours"
     isOurs :: Core.Address -> s -> (Maybe HdAddress, s)
-    -- Marks the state as empty and enables us to skip single or batch calls
+    -- | Marks the state as empty and enables us to skip single or batch calls
     -- to isOurs in the case of trivial state.
     isOursSkip :: s -> Bool
 

--- a/src/Cardano/Wallet/Kernel/Migration.hs
+++ b/src/Cardano/Wallet/Kernel/Migration.hs
@@ -101,7 +101,7 @@ restore :: Kernel.PassiveWallet
         -> IO ()
 restore pw forced esk = do
     let logMsg = pw ^. Kernel.walletLogMessage
-        nm     = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
+        nm = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
         rootId = eskToHdRootId nm esk
 
     let -- DEFAULTS for wallet restoration
@@ -117,7 +117,7 @@ restore pw forced esk = do
                          defaultAddress
                          defaultWalletName
                          defaultAssuranceLevel
-                         esk
+                         (rootId,esk)
 
     case res of
          Right (restoredRoot, balance) -> do

--- a/src/Cardano/Wallet/Kernel/Pending.hs
+++ b/src/Cardano/Wallet/Kernel/Pending.hs
@@ -118,7 +118,7 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
     where
         (txOut :: [TxOut]) = NE.toList $ (_txOutputs . taTx $ tx)
 
-        -- Prefiltering context for _all_ wallets
+        -- Prefiltering context for HdRnd and Eos wallet types
         fullPref
             :: DB
             -> IO ( Map HdRootId EncryptedSecretKey
@@ -131,19 +131,19 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
             seqs <- getHdSeqWallets db
             return (rnds, seqs)
 
-        -- Provides the prefiltering context for all accounts in a wallet.
+        -- Provides the prefilter context for all accounts in this HdRnd wallet.
         --
-        -- If the accountId is part of an HdRnd wallet, then this selects
-        -- the HdRootId of that wallet.
+        -- If the given accountId is part of an HdRnd wallet, then this selects
+        -- all HdAccountId's that have the same root of the given accountId.
         thisPrefRnd
             :: Map HdRootId EncryptedSecretKey
             -> Map HdRootId EncryptedSecretKey
         thisPrefRnd
             = Map.filterWithKey (\r _ -> accountId ^. hdAccountIdParent == r)
 
-        -- Provides the prefiltering context for all accounts in a wallet.
+        -- Provides the prefilter context for all accounts in this Eos wallet.
         --
-        -- If the accountId is part of an HdSeq wallet, then this selects
+        -- If the given accountId is part of an Eos wallet, then this selects
         -- all HdAccountId's that have the same root of the given accountId.
         thisPrefSeq
             :: Map HdAccountId (AddressPool Address)
@@ -151,7 +151,7 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
         thisPrefSeq
             = Map.filterWithKey (\a _ -> accountId ^. hdAccountIdParent == a ^. hdAccountIdParent)
 
-        -- filter the Tx outputs for "ours" in the prefilter context _s_
+        -- Prefilter "our" Tx outputs given the prefilter context _s_
         allOurs
             :: IsOurs s
             => s

--- a/src/Cardano/Wallet/Kernel/Pending.hs
+++ b/src/Cardano/Wallet/Kernel/Pending.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.Kernel.Pending (
 import           Universum hiding (State)
 
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
 
 import           Control.Concurrent.MVar (modifyMVar_)
 
@@ -28,7 +29,7 @@ import           Cardano.Wallet.Kernel.DB.InDb
 import qualified Cardano.Wallet.Kernel.DB.Spec.Pending as Pending
 import           Cardano.Wallet.Kernel.DB.TxMeta (TxMeta, putTxMeta)
 import           Cardano.Wallet.Kernel.Internal
-import           Cardano.Wallet.Kernel.Read (getWalletCredentials)
+import           Cardano.Wallet.Kernel.Read (getWalletCredentials, getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Submission (Cancelled, addPending)
 import           Cardano.Wallet.Kernel.Util.Core
 
@@ -86,17 +87,22 @@ newTx :: forall e. ActiveWallet
       -> ([HdAddress] -> IO (Either e ())) -- ^ the update to run, takes ourAddrs as arg
       -> IO (Either e TxMeta)
 newTx ActiveWallet{..} accountId tx partialMeta upd = do
+    snapshot <- getWalletSnapshot walletPassive
     -- run the update
-    allCredentials <- getWalletCredentials walletPassive
-    let allOurAddresses = fst <$> allOurs allCredentials
+    hdRnds <- getWalletCredentials snapshot
+                (walletPassive ^. walletKeystore)
+                (walletPassive ^. walletProtocolMagic)
+                (walletPassive ^. walletLogMessage)
+
+    let allOurAddresses = fst <$> allOurs hdRnds
     res <- upd $ allOurAddresses
     case res of
         Left e   -> return (Left e)
         Right () -> do
             -- process transaction on success
             -- myCredentials should be a list with a single element.
-            let myCredentials = filter (\(hdRoot, _) -> accountId ^. hdAccountIdParent == hdRoot) allCredentials
-                ourOutputCoins = snd <$> allOurs myCredentials
+            let thisHdRndRoot = Map.filterWithKey (\hdRoot _ -> accountId ^. hdAccountIdParent == hdRoot) hdRnds
+                ourOutputCoins = snd <$> allOurs thisHdRndRoot
                 gainedOutputCoins = sumCoinsUnsafe ourOutputCoins
                 allOutsOurs = length ourOutputCoins == length txOut
                 txMeta = partialMeta allOutsOurs gainedOutputCoins
@@ -109,7 +115,7 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
         -- | NOTE: we recognise addresses in the transaction outputs that belong to _all_ wallets,
         --  not only for the wallet to which this transaction is being submitted
         allOurs
-            :: [(HdRootId, EncryptedSecretKey)]
+            :: Map HdRootId EncryptedSecretKey
             -> [(HdAddress, Coin)]
         allOurs = evalState $ fmap catMaybes $ forM txOut $ \out -> do
             fmap (, txOutValue out) <$> state (isOurs $ txOutAddress out)

--- a/src/Cardano/Wallet/Kernel/Pending.hs
+++ b/src/Cardano/Wallet/Kernel/Pending.hs
@@ -33,7 +33,8 @@ import           Cardano.Wallet.Kernel.DB.InDb
 import qualified Cardano.Wallet.Kernel.DB.Spec.Pending as Pending
 import           Cardano.Wallet.Kernel.DB.TxMeta (TxMeta, putTxMeta)
 import           Cardano.Wallet.Kernel.Internal
-import           Cardano.Wallet.Kernel.Read (getHdRndWallets, getHdSeqWallets, getWalletSnapshot)
+import           Cardano.Wallet.Kernel.Read (getEosPools, getHdRndWallets, 
+                    getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Submission (Cancelled, addPending)
 import           Cardano.Wallet.Kernel.Util.Core
 
@@ -128,7 +129,7 @@ newTx ActiveWallet{..} accountId tx partialMeta upd = do
                         (walletPassive ^. walletKeystore)
                         (walletPassive ^. walletProtocolMagic)
                         (walletPassive ^. walletLogMessage)
-            seqs <- getHdSeqWallets db
+            seqs <- getEosPools db
             return (rnds, seqs)
 
         -- Provides the prefilter context for all accounts in this HdRnd wallet.

--- a/src/Cardano/Wallet/Kernel/Read.hs
+++ b/src/Cardano/Wallet/Kernel/Read.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE MultiWayIf #-}
+
 -- | Read-only access to the DB
 module Cardano.Wallet.Kernel.Read (
     -- * Read-only access to the DB
     DB -- opaque
+    -- * Exceptions
+  , GetAddressPoolGapError (..)
     -- ** Helper
+  , addressPoolGapByRootId
   , getHdRndWallets
-  , getHdSeqWallets
+  , getEosPools
     -- ** The only effectful getter you will ever need
   , getWalletSnapshot
     -- ** Pure getters acting on a DB snapshot
@@ -13,21 +18,29 @@ module Cardano.Wallet.Kernel.Read (
 
 import           Universum hiding (State)
 
+
 import           Data.Acid.Advanced (query')
 import qualified Data.Map.Strict as Map
-import           Formatting (sformat, (%))
+import           Data.List (nub)
+import           Formatting (bprint, build, sformat, (%))
+import qualified Formatting.Buildable
 import           Serokell.Util (listJson)
 
 import           Pos.Core (Address)
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
-import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic)
+import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, PublicKey)
 import           Pos.Util.Wlog (Severity (..))
 
 import           Cardano.Wallet.Kernel.AddressPool (AddressPool)
-import           Cardano.Wallet.Kernel.DB.AcidState (DB, Snapshot (..))
+import           Cardano.Wallet.Kernel.AddressPoolGap (AddressPoolGap)
+import           Cardano.Wallet.Kernel.DB.AcidState (DB, Snapshot (..),
+                    dbHdWallets)
 import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId)
-import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId)
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId, HdRoot,
+                    HdAccountBase (..), hdAccountBase, hdRootId, hdWalletsRoots,
+                    mkAddressPoolExisting)
 import           Cardano.Wallet.Kernel.DB.Read as Getters
+import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 
@@ -69,8 +82,62 @@ getHdRndWallets snapshot ks pm logger = do
 
 -- Get HD Sequential wallet accounts from Acidstate, along with the
 -- associated AddressPool required for prefiltering each account.
-getHdSeqWallets
-    :: DB
-    -> IO (Map HdAccountId (AddressPool Address))
-getHdSeqWallets _db
-    = return Map.empty -- TODO @uroboros
+getEosPools
+    :: MonadIO m
+    => DB
+    -> m (Map HdAccountId (AddressPool Address))
+getEosPools db
+    = return . Map.fromList $ concatMap toAccountAddressPools' allRoots
+  where
+    allRoots = IxSet.toList $ db ^. dbHdWallets . hdWalletsRoots
+
+    toAccountAddressPools' root
+        = toAccountAddressPools root (addressPoolGapByRootId (root ^. hdRootId) db)
+
+    mkPool gap (accId,pk)
+        = case mkAddressPoolExisting (error "TODO @@@ mkAddress") pk gap (error "TODO @@@addrs") of
+                Left invalidPoolErr -> error (sformat build invalidPoolErr)
+                Right pool -> (accId, pool)
+
+    toAccountAddressPools
+        :: HdRoot
+        -> Either GetAddressPoolGapError ([(HdAccountId, PublicKey)], AddressPoolGap)
+        -> [(HdAccountId, AddressPool Address)]
+    toAccountAddressPools _root eitherAccounts-- (accs,gap)
+        = case eitherAccounts of
+            Left getPoolErr -> error (sformat build getPoolErr)
+            Right (accs,gap) -> map (mkPool gap) accs
+
+addressPoolGapByRootId
+    :: HdRootId
+    -> DB
+    -> Either GetAddressPoolGapError ([(HdAccountId, PublicKey)], AddressPoolGap)
+addressPoolGapByRootId rootId db = do
+    let accounts = IxSet.toList $ Getters.accountsByRootId db rootId
+        bases = flip map accounts $ \hdAccount -> case hdAccount ^. hdAccountBase of
+                    -- It is EOS-wallet, so all accounts must have EO-branch.
+                    HdAccountBaseFO _       -> Left ()
+                    HdAccountBaseEO accId accPk gap -> Right (accId,accPk,gap)
+        (errors, accs) = partitionEithers bases
+        gaps = map  (\(_,_,gap) -> gap) accs
+        accs' = map (\(accId,accPk,_) -> (accId,accPk)) accs
+    if | null accs             -> Left $ GetEosWalletErrorNoAccounts anId
+       | not . null $ errors   -> Left $ GetEosWalletErrorWrongAccounts anId
+       | length (nub gaps) > 1 -> Left $ GetEosWalletErrorGapsDiffer anId
+       | otherwise             -> let [gap] = gaps in Right (accs',gap)
+  where
+    anId = sformat build rootId
+
+data GetAddressPoolGapError =
+      GetEosWalletErrorNoAccounts Text
+    | GetEosWalletErrorWrongAccounts Text
+    | GetEosWalletErrorGapsDiffer Text
+    deriving Eq
+
+instance Buildable GetAddressPoolGapError where
+    build (GetEosWalletErrorNoAccounts txt) =
+        bprint ("GetEosWalletErrorNoAccounts " % build) txt
+    build (GetEosWalletErrorWrongAccounts txt) =
+        bprint ("FO-accounts found in EOS-wallet " % build) txt
+    build (GetEosWalletErrorGapsDiffer txt) =
+        bprint ("Address pool gaps differ, for EOS-wallet " % build) txt

--- a/src/Cardano/Wallet/Kernel/Read.hs
+++ b/src/Cardano/Wallet/Kernel/Read.hs
@@ -66,11 +66,11 @@ getHdRndWallets snapshot ks pm logger = do
     errMissing :: [HdRootId] -> Text
     errMissing = sformat ("Root key missing for " % listJson)
 
--- TODO @uroboros
--- Get HD Sequential wallet accounts along with the associated AddressPool
--- required for prefiltering each account.
+
+-- Get HD Sequential wallet accounts from Acidstate, along with the
+-- associated AddressPool required for prefiltering each account.
 getHdSeqWallets
     :: DB
     -> IO (Map HdAccountId (AddressPool Address))
 getHdSeqWallets _db
-    = return Map.empty
+    = return Map.empty -- TODO @uroboros

--- a/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/src/Cardano/Wallet/Kernel/Restore.hs
@@ -66,7 +66,7 @@ import           Cardano.Wallet.Kernel.Types (RawResolvedBlock (..),
                      rawResolvedBlockInputs, rawResolvedContext, rawTimestamp)
 import           Cardano.Wallet.Kernel.Util.Core (utxoBalance)
 import           Cardano.Wallet.Kernel.Wallets (createWalletHdRnd,
-                     createWalletEos, mkAddressPool, mkCreateEosWallet,
+                     createWalletEos, mkAccountAddressPool, mkCreateEosWallet,
                      mkCreateHdRndWallet, mkRestoreEosWallet,
                      mkRestoreHdRndWallet)
 
@@ -152,12 +152,12 @@ restoreEosWallet pw accounts gap assurance name
         = makePubKeyAddressBoot . makeNetworkMagic $ pw ^. walletProtocolMagic
 
     -- Construct the prefiltering context for this wallet, we need the rootId
-    -- to get build the AccountId's for each account pub key 
+    -- to get build the AccountId's for each account pub key
     prefContext
         :: HD.HdRootId
         -> Map HD.HdAccountId (AddressPool Address)
     prefContext rootId
-        = M.fromList $ mkAddressPool rootId gap pkToAddr <$> accounts
+        = M.fromList $ mkAccountAddressPool rootId gap pkToAddr <$> accounts
 
     createWallet = createWalletEos pw assurance name
 

--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -24,6 +24,7 @@ import qualified Formatting as F
 import qualified Formatting.Buildable
 
 import           Data.Acid.Advanced (update')
+import qualified Data.Map.Strict as Map
 
 import           Pos.Chain.Txp (Utxo)
 import           Pos.Core (Address, Timestamp)
@@ -352,7 +353,7 @@ defaultHdAddressWith :: EncryptedSecretKey
                      -> Address
                      -> Maybe HdAddress
 defaultHdAddressWith esk rootId addr =
-    fst $ HD.isOurs addr [(rootId, esk)]
+    fst $ HD.isOurs addr (Map.singleton rootId esk)
 
 defaultHdAccountId :: HD.HdRootId -> HdAccountId
 defaultHdAccountId rootId = HdAccountId rootId (HdAccountIx firstHardened)

--- a/src/Cardano/Wallet/WalletLayer.hs
+++ b/src/Cardano/Wallet/WalletLayer.hs
@@ -5,8 +5,8 @@ module Cardano.Wallet.WalletLayer
     , CreateWallet(..)
     -- ** Errors
     , CreateWalletError(..)
+    , GetAddressPoolGapError (..)
     , GetWalletError(..)
-    , GetAddressPoolGapError(..)
     , GetEosWalletError(..)
     , UpdateWalletError(..)
     , UpdateWalletPasswordError(..)
@@ -64,6 +64,7 @@ import           Cardano.Wallet.Kernel.DB.TxMeta.Types
 import           Cardano.Wallet.Kernel.DB.Util.IxSet (IxSet)
 import qualified Cardano.Wallet.Kernel.Transactions as Kernel
 import qualified Cardano.Wallet.Kernel.Wallets as Kernel
+import           Cardano.Wallet.Kernel.Read (GetAddressPoolGapError (..))
 import           Cardano.Wallet.WalletLayer.ExecutionTimeLimit
                      (TimeExecutionLimit)
 import           Cardano.Wallet.WalletLayer.Kernel.Conv (InvalidRedemptionCode)
@@ -114,20 +115,6 @@ instance Buildable GetWalletError where
         bprint ("GetWalletErrorNotFound " % build) walletId
     build (GetWalletWalletIdDecodingFailed txt) =
         bprint ("GetWalletWalletIdDecodingFailed " % build) txt
-
-data GetAddressPoolGapError =
-      GetEosWalletErrorNoAccounts Text
-    | GetEosWalletErrorWrongAccounts Text
-    | GetEosWalletErrorGapsDiffer Text
-    deriving Eq
-
-instance Buildable GetAddressPoolGapError where
-    build (GetEosWalletErrorNoAccounts txt) =
-        bprint ("GetEosWalletErrorNoAccounts " % build) txt
-    build (GetEosWalletErrorWrongAccounts txt) =
-        bprint ("FO-accounts found in EOS-wallet " % build) txt
-    build (GetEosWalletErrorGapsDiffer txt) =
-        bprint ("Address pool gaps differ, for EOS-wallet " % build) txt
 
 data GetEosWalletError =
       GetEosWalletError Kernel.UnknownHdRoot

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -124,7 +124,7 @@ createWallet wallet newWalletRequest = liftIO $ do
                       (Just (hdAddress ^. HD.hdAddressAddress . fromDb))
                       (HD.WalletName walletName)
                       hdAssuranceLevel
-                      esk
+                      (rootId,esk)
 
                 -- Return the wallet information, with an updated balance.
                 let root' = mkRoot walletName (toAssuranceLevel hdAssuranceLevel) root

--- a/test/unit/Util/Prefiltering.hs
+++ b/test/unit/Util/Prefiltering.hs
@@ -17,7 +17,7 @@ prefilterUtxo
     -> EncryptedSecretKey
     -> Utxo
     -> Map HdAccountId (Utxo, [HdAddress])
-prefilterUtxo rootId esk utxo = flip evalState [(rootId, esk)] $
+prefilterUtxo rootId esk utxo = flip evalState (Map.singleton rootId esk) $
     fmap (Map.unionsWith (<>)) $ forM (Map.toList utxo) $ \(txin, txout) -> do
         let addr = txOutAddress $ toaOut txout
         state (isOurs addr) <&> \case


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-wallet/issues/239

<p align="right">#</p>

# Overview

- [x] I have extended `prefilterBlocks` in the BListener to also prefilter for EOS wallets (this means that ApplyBlock will prefilter for EOS wallets as well)
- [x] I have extended newPending/newForeign prefiltering of tx outputs to deal with Eos wallet addresses
- [x] I have implemented restoreEosWallet and refactored the HdRnd restoreWallet (to enable sharing of code)

# TODO

- [ ] reconstruct EOS wallets/address pools  from Acidstate on wallet startup
- [ ] at entry point for Restoration, dispatch between Eos/HdRnd restorations
- [ ] remove `isOursSkip` from IsOurs class (try out Matt's idea for this)
- [ ] split Eos/Rnd wallet code more clearly (e.g. in Wallets.hs / Restore.hs)
- [ ] improve naming of Wallets.hs create* functions
- [ ] extend restoreKnownWallet and other restore* to EOS, where applicable

# Comments

- [ ] this is still WIP because I've not wired up the reading of EOS wallets from AcidState
