### PR TITLE
Add error support when not enough utxo is met upon multioutput …

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -363,6 +363,7 @@ test-suite unit
   ghc-options:
       -threaded -rtsopts
       -Wall
+      -Werror
       -O2
 
   build-depends:

--- a/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -305,6 +305,9 @@ newTransactionError e = case e of
     Kernel.NewTransactionInvalidTxIn ->
             V1.SignedTxSubmitError "NewTransactionInvalidTxIn"
 
+    (Kernel.NewTransactionNotEnoughUtxoFragmentation (Kernel.NumberOfMissingUtxos missingUtxo)) ->
+        V1.UtxoNotEnoughFragmented (V1.ErrUtxoNotEnoughFragmented missingUtxo V1.msgUtxoNotEnoughFragmented)
+
 redeemAdaError :: RedeemAdaError -> V1.WalletError
 redeemAdaError e = case e of
     (RedeemAdaError e') -> case e' of

--- a/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.Kernel.Transactions (
     , PaymentError(..)
     , EstimateFeesError(..)
     , RedeemAdaError(..)
+    , NumberOfMissingUtxos(..)
     , cardanoFee
     , mkStdTx
     , prepareUnsignedTxWithSources
@@ -87,6 +88,17 @@ import           UTxO.Util (shuffleNE)
   Generating payments and estimating fees
 -------------------------------------------------------------------------------}
 
+data NumberOfMissingUtxos = NumberOfMissingUtxos Int
+
+instance Buildable NumberOfMissingUtxos where
+    build (NumberOfMissingUtxos number) =
+        bprint ("NumberOfMissingUtxos " % build) number
+
+instance Arbitrary NumberOfMissingUtxos where
+    arbitrary = oneof [ NumberOfMissingUtxos <$> arbitrary
+                      ]
+
+
 data NewTransactionError =
     NewTransactionUnknownAccount UnknownHdAccount
   | NewTransactionUnknownAddress UnknownHdAddress
@@ -94,6 +106,7 @@ data NewTransactionError =
   | NewTransactionErrorCreateAddressFailed Kernel.CreateAddressError
   | NewTransactionErrorSignTxFailed SignTransactionError
   | NewTransactionInvalidTxIn
+  | NewTransactionNotEnoughUtxoFragmentation NumberOfMissingUtxos
 
 instance Buildable NewTransactionError where
     build (NewTransactionUnknownAccount err) =
@@ -108,6 +121,9 @@ instance Buildable NewTransactionError where
         bprint ("NewTransactionErrorSignTxFailed " % build) err
     build NewTransactionInvalidTxIn =
         bprint "NewTransactionInvalidTxIn"
+    build (NewTransactionNotEnoughUtxoFragmentation err) =
+        bprint ("NewTransactionNotEnoughUtxoFragmentation" % build) err
+
 
 instance Arbitrary NewTransactionError where
     arbitrary = oneof [
@@ -119,6 +135,7 @@ instance Arbitrary NewTransactionError where
       , NewTransactionErrorCreateAddressFailed <$> arbitrary
       , NewTransactionErrorSignTxFailed <$> arbitrary
       , pure NewTransactionInvalidTxIn
+      , NewTransactionNotEnoughUtxoFragmentation <$> arbitrary
       ]
 
 data PaymentError = PaymentNewTransactionError NewTransactionError
@@ -216,6 +233,10 @@ newUnsignedTransaction ActiveWallet{..} options accountId payees = runExceptT $ 
     availableUtxo <- withExceptT NewTransactionUnknownAccount $ exceptT $
                        currentAvailableUtxo snapshot accountId
 
+
+    withExceptT NewTransactionNotEnoughUtxoFragmentation $ exceptT $
+        checkUtxoFragmentation payees availableUtxo
+
     -- STEP 1: Run coin selection.
     CoinSelFinalResult inputs outputs coins <-
       withExceptT NewTransactionErrorCoinSelectionFailed $ ExceptT $
@@ -248,6 +269,20 @@ newUnsignedTransaction ActiveWallet{..} options accountId payees = runExceptT $ 
 
     toTxOut :: (Address, Coin) -> TxOutAux
     toTxOut (a, c) = TxOutAux (TxOut a c)
+
+    checkUtxoFragmentation
+        :: NonEmpty (Address, Coin)
+        -> Utxo
+        -> Either NumberOfMissingUtxos ()
+    checkUtxoFragmentation outputs inputs =
+        let numberOfUtxo = Map.size inputs
+            numberOfOutputs = NonEmpty.length outputs
+            diff = numberOfOutputs - numberOfUtxo
+        in if diff > 0 then
+            Left $ NumberOfMissingUtxos diff
+           else
+            Right ()
+
 
 -- | Creates a new unsigned transaction.
 --

--- a/test/unit/Servant/JsendCompliance.hs
+++ b/test/unit/Servant/JsendCompliance.hs
@@ -96,4 +96,3 @@ type family ResponseTypes' c api :: [*] where
   ResponseTypes' c (e :> api) = ResponseTypes' c api
   ResponseTypes' c (a :<|> b) = AppendList (ResponseTypes' c a) (ResponseTypes' c b)
   ResponseTypes' c api = '[]
-

--- a/test/unit/Servant/JsendCompliance.hs
+++ b/test/unit/Servant/JsendCompliance.hs
@@ -20,7 +20,7 @@ import           Servant.Swagger.Internal.Test (props)
 import           Servant.Swagger.Internal.TypeLevel (AddBodyType, AppendList,
                      Every, Nub, TMap)
 import           Test.QuickCheck (Arbitrary (..), Property, counterexample,
-                     (.&&.), (===))
+                     (===))
 
 -- | For each endpoint, create a property that verifies that serializing
 -- the response for that endpoint is JSend compliant.


### PR DESCRIPTION
#190 

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Integration test illustrating the following scenarios were added:
- [x] A multi-output transaction fails because there's not enough UTxO to cover for all outputs
- [x] A multi-output transaction succeeds
- [x] The API returns a more meaningful error when the case for (failing) multi-output is encountered, suggesting the user to have a look at /api/v1/wallets/{walletId}/statistics/utxo

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
