### PR TITLE
review creation of externally owned wallets

### DIFF
--- a/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -54,6 +54,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet (
     -- *** Account
   , hdAccountId
   , hdAccountBase
+  , hdAccountBaseId
   , hdAccountName
   , hdAccountState
   , hdAccountStateCurrent
@@ -297,7 +298,8 @@ data HdAccountBase =
           _hdAccountBaseEOId             :: !HdAccountId
         , _hdAccountBaseEOAccountKey     :: !Core.PublicKey
         , _hdAccountBaseEOAddressPoolGap :: !AddressPoolGap
-      }
+        }
+    deriving (Eq, Ord)
 
 instance Arbitrary HdAccountBase where
     arbitrary = oneof
@@ -464,19 +466,22 @@ deriveSafeCopy 1 'base ''HdAccountIncomplete
   Derived lenses
 -------------------------------------------------------------------------------}
 
-getHdAccountId :: HdAccountBase -> HdAccountId
-getHdAccountId (HdAccountBaseFO accountId)     = accountId
-getHdAccountId (HdAccountBaseEO accountId _ _) = accountId
+hdAccountBaseId :: Lens' HdAccountBase HdAccountId
+hdAccountBaseId = lens getHdAccountId setHdAccountId
+  where
+    getHdAccountId :: HdAccountBase -> HdAccountId
+    getHdAccountId (HdAccountBaseFO accountId)     = accountId
+    getHdAccountId (HdAccountBaseEO accountId _ _) = accountId
 
-setHdAccountId :: HdAccountBase -> HdAccountId -> HdAccountBase
-setHdAccountId (HdAccountBaseFO _) newAccountId = HdAccountBaseFO newAccountId
-setHdAccountId (HdAccountBaseEO _ pKey gap) newAccountId = HdAccountBaseEO newAccountId pKey gap
+    setHdAccountId :: HdAccountBase -> HdAccountId -> HdAccountBase
+    setHdAccountId (HdAccountBaseFO _) newAccountId = HdAccountBaseFO newAccountId
+    setHdAccountId (HdAccountBaseEO _ pKey gap) newAccountId = HdAccountBaseEO newAccountId pKey gap
 
 hdAccountId :: Lens' HdAccount HdAccountId
-hdAccountId = hdAccountBase . lens getHdAccountId setHdAccountId
+hdAccountId = hdAccountBase . hdAccountBaseId
 
 hdAccountRootId :: Lens' HdAccount HdRootId
-hdAccountRootId = hdAccountBase . lens getHdAccountId setHdAccountId . hdAccountIdParent
+hdAccountRootId = hdAccountBase . hdAccountBaseId . hdAccountIdParent
 
 hdAddressAccountId :: Lens' HdAddress HdAccountId
 hdAddressAccountId = hdAddressId . hdAddressIdParent

--- a/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -157,10 +157,8 @@ initHdAccount accountBase st = HdAccount {
     , _hdAccountAutoPkCounter = AutoIncrementKey 0
     }
   where
-    defName = AccountName $ sformat ("Account: " % build) accountIx
-    HdAccountId _ accountIx = case accountBase of
-        HdAccountBaseFO accId     -> accId
-        HdAccountBaseEO accId _ _ -> accId
+    defName = AccountName $ sformat ("Account: " % build) (accId ^. hdAccountIdIx)
+    accId   = accountBase ^. hdAccountBaseId
 
 {-------------------------------------------------------------------------------
   Pretty printing

--- a/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/src/Cardano/Wallet/Kernel/Restore.hs
@@ -119,8 +119,12 @@ restoreWallet pw hasSpendingPassword defaultCardanoAddress name assurance esk
     case walletInitInfo of
         WalletCreate utxos -> do
             root <- createWalletHdRnd'
-                $ \root defaultHdAccount defaultHdAddress -> Left
-                $ CreateHdWallet root defaultHdAccount defaultHdAddress utxos
+                $ \root defaultHdAccount defaultHdAddress -> do
+                    let defUtxo = M.singleton
+                            (HD.HdAccountBaseFO defaultHdAccount)
+                            (mempty, maybeToList defaultHdAddress)
+                    let utxos' = M.mapKeys HD.HdAccountBaseFO utxos
+                    Left $ CreateHdWallet root (M.unionWith (<>) utxos' defUtxo)
             return $ fmap (, mkCoin 0) root
         WalletRestore utxos tgt -> do
             -- Create the wallet for restoration, deleting the wallet first if it

--- a/test/unit/Test/Spec/Addresses.hs
+++ b/test/unit/Test/Spec/Addresses.hs
@@ -32,8 +32,8 @@ import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.DB.AcidState
 import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
-                     HasSpendingPassword (..), HdAccountId (..),
-                     HdAccountIx (..), WalletName (..))
+                     HasSpendingPassword (..), HdAccountBase (..),
+                     HdAccountId (..), HdAccountIx (..), WalletName (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (initHdRoot)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
@@ -87,7 +87,10 @@ prepareFixtures nm = do
         hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 
     return $ \pw -> do
-        void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)
+        let accs0 = M.unionWith (<>)
+                (M.singleton (HdAccountBaseFO hdAccountId) (mempty, maybeToList hdAddress))
+                (M.mapKeys HdAccountBaseFO accounts)
+        void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot accs0)
         return $ Fixture {
                            fixtureHdRootId = newRootId
                          , fixtureAccountId = newAccountId

--- a/test/unit/Test/Spec/GetTransactions.hs
+++ b/test/unit/Test/Spec/GetTransactions.hs
@@ -46,9 +46,9 @@ import           Cardano.Wallet.Kernel.DB.AcidState
 import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, decodeHdRootId,
                      eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
-                     HasSpendingPassword (..), HdAccountId (..),
-                     HdAccountIx (..), HdAddressIx (..), HdRoot (..),
-                     WalletName (..), hdAccountIdIx)
+                     HasSpendingPassword (..), HdAccountBase (..),
+                     HdAccountId (..), HdAccountIx (..), HdAddressIx (..),
+                     HdRoot (..), WalletName (..), hdAccountIdIx)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (initHdRoot)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
@@ -139,8 +139,10 @@ prepareFixtures nm initialBalance = do
             let accounts    = Kernel.prefilterUtxo fixtureHdRootId fixtureESK fixtureUtxo
                 hdAccountId = Kernel.defaultHdAccountId fixtureHdRootId
                 hdAddress   = Kernel.defaultHdAddress nm fixtureESK emptyPassphrase fixtureHdRootId
-
-            void $ liftIO $ update (pw ^. wallets) (CreateHdWallet fixtureHdRoot hdAccountId hdAddress accounts)
+            let accs0 = M.unionWith (<>)
+                    (M.singleton (HdAccountBaseFO hdAccountId) (mempty, maybeToList hdAddress))
+                    (M.mapKeys HdAccountBaseFO accounts)
+            void $ liftIO $ update (pw ^. wallets) (CreateHdWallet fixtureHdRoot accs0)
         return $ Fixture {
               fixture = fixt
             , fixturePw = pw

--- a/test/unit/Test/Spec/NewPayment.hs
+++ b/test/unit/Test/Spec/NewPayment.hs
@@ -43,9 +43,9 @@ import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
 import           Cardano.Wallet.Kernel.DB.AcidState
 import           Cardano.Wallet.Kernel.DB.HdRootId (HdRootId, eskToHdRootId)
 import           Cardano.Wallet.Kernel.DB.HdWallet (AssuranceLevel (..),
-                     HasSpendingPassword (..), HdAccountId (..),
-                     HdAccountIx (..), HdAddressIx (..), WalletName (..),
-                     hdAccountIdIx)
+                     HasSpendingPassword (..), HdAccountBase (..),
+                     HdAccountId (..), HdAccountIx (..), HdAddressIx (..),
+                     WalletName (..), hdAccountIdIx)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Create (initHdRoot)
 import           Cardano.Wallet.Kernel.DB.HdWallet.Derivation
                      (HardeningMode (..), deriveIndex)
@@ -121,7 +121,10 @@ prepareFixtures nm initialBalance toPay = do
             hdAccountId = Kernel.defaultHdAccountId newRootId
             hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 
-        void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)
+        let accs0 = M.unionWith (<>)
+                (M.singleton (HdAccountBaseFO hdAccountId) (mempty, maybeToList hdAddress))
+                (M.mapKeys HdAccountBaseFO accounts)
+        void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot accs0)
         return $ Fixture {
                            fixtureHdRootId = newRootId
                          , fixtureAccountId = newAccountId

--- a/test/unit/Wallet/Inductive/Cardano.hs
+++ b/test/unit/Wallet/Inductive/Cardano.hs
@@ -242,11 +242,11 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
             walletName
             assuranceLevel
             esk
-            (\root defaultAccount defAddress ->
-                Left $ DB.CreateHdWallet root
-                                         defaultAccount
-                                         defAddress
-                                         (prefilterUtxo (root ^. HD.hdRootId) esk utxo)
+            (\root defaultAccount defAddress -> do
+                let accs0 = Map.unionWith (<>)
+                        (Map.singleton (HD.HdAccountBaseFO defaultAccount) (mempty, maybeToList defAddress))
+                        (Map.mapKeys HD.HdAccountBaseFO (prefilterUtxo (root ^. HD.hdRootId) esk utxo))
+                Left $ DB.CreateHdWallet root accs0
             )
         case res of
              Left e -> createWalletErr (STB e)


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#236</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- Remove the intermediate type 'AccountUpdateBase' in favor of plain 'HdAccountBase'

- Provide a Lens' HdAccountBase HdAccountId to easily access account id
  from a base without pattern matching all the time

- Unify 'createHdWallet' and 'createEosHdWallet' to remove duplication
  and work with a slightly highler level abstraction at the DB level
  (provided the base is constructed correctly by the caller)

- Review 'createEosHdWallet' in the WalletLayer & Kernel to have types
  better reflecting an actual _real life scenario_

# Comments

<!-- Additional comments or screenshots to attach if any -->

This is some preparatory work in order to implement working integration tests for creation of EOS wallets.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
