### PR TITLE
Start node api server as a plugin

### DIFF
--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -7,8 +7,8 @@ import           Pos.Launcher (launchNode)
 import           Pos.Util.CompileInfo (withCompileInfo)
 
 import           Cardano.Wallet.Action (actionWithWallet)
-import           Cardano.Wallet.Server.CLI (ChooseWalletBackend (..),
-                     WalletStartupOptions (..), getWalletNodeOptions)
+import           Cardano.Wallet.Server.CLI (WalletStartupOptions (..),
+                     getWalletNodeOptions)
 
 
 -- | The main entrypoint for the Wallet.
@@ -20,9 +20,4 @@ main = withCompileInfo $ do
 
     putText "Wallet is starting..."
 
-    launchNode nArgs cArgs lArgs $ case wArgs of
-        WalletLegacy _ ->
-            error "Legacy wallet is now disabled. This option will be removed soon."
-
-        WalletNew p ->
-            actionWithWallet p
+    launchNode nArgs cArgs lArgs (actionWithWallet wArgs)

--- a/src/Cardano/Wallet/Action.hs
+++ b/src/Cardano/Wallet/Action.hs
@@ -38,6 +38,7 @@ import           Cardano.Wallet.Server.Middlewares
 import qualified Cardano.Wallet.Server.Plugins as Plugins
 import           Cardano.Wallet.WalletLayer (PassiveWalletLayer)
 import qualified Cardano.Wallet.WalletLayer.Kernel as WalletLayer.Kernel
+import           Pos.Web (TlsParams (..))
 
 
 -- | The "workhorse" responsible for starting a Cardano edge node plus a number of extra plugins.
@@ -59,12 +60,15 @@ actionWithWallet
     ntpStatus <- withNtpClient (ntpClientSettings ntpConfig)
     userSecret <- readTVarIO (ncUserSecret $ nrContext nodeRes)
 
+    logInfo $ "Params: " <> show params
+
     let (nodeIp, nodePort) = walletNodeAddress
+    let walletNodeTlsCaCertPath = tpCaPath $ maybe (error "TODO") id walletTLSParams
     nodeClient <- Plugins.setupNodeClient
          (BS8.unpack nodeIp, fromIntegral nodePort)
          walletNodeTlsClientCert
          walletNodeTlsCaCertPath
-         walletNodeTlsPrivKey
+         walletNodeTlsClientKey
 
     let nodeState = newNodeStateAdaptor
             genesisConfig

--- a/src/Cardano/Wallet/Action.hs
+++ b/src/Cardano/Wallet/Action.hs
@@ -112,6 +112,7 @@ actionWithWallet
 
             -- Periodically compact & snapshot the acid-state database.
             , ("acid state cleanup", Plugins.acidStateSnapshots (view Kernel.Internal.wallets (snd w)) params dbMode)
+            , ("node monitoring server", Plugins.nodeAPIServer params genesisConfig ntpConfig nodeRes)
             ]
         -- The corresponding wallet documention, served as a different
         -- server which doesn't require client x509 certificates to

--- a/src/Cardano/Wallet/Server.hs
+++ b/src/Cardano/Wallet/Server.hs
@@ -17,7 +17,6 @@ import qualified Cardano.Wallet.API.Internal.Handlers as Internal
 import qualified Cardano.Wallet.API.V1.Handlers as V1
 import           Cardano.Wallet.API.V1.Swagger (swaggerSchemaUIServer)
 import qualified Cardano.Wallet.API.V1.Swagger as Swagger
-import           Cardano.Wallet.Server.CLI (RunMode (..))
 import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..))
 
 -- | Serve the REST interface to the wallet
@@ -27,9 +26,8 @@ import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..))
 walletServer
     :: NodeHttpClient
     -> ActiveWalletLayer IO
-    -> RunMode
     -> Server WalletAPI
-walletServer nc w _ =
+walletServer nc w =
     v1Handler
     :<|> internalHandler
   where

--- a/src/Cardano/Wallet/Server/CLI.hs
+++ b/src/Cardano/Wallet/Server/CLI.hs
@@ -76,8 +76,12 @@ data WalletBackendParams = WalletBackendParams
     -- ^ The IP address and port for the node backend.
     , walletNodeTlsClientCert :: FilePath
     -- ^ A filepath to the Node's public certficate
+    , walletNodeTlsServerCert :: FilePath
+    -- ^ A filepath to the Node's private certficate
     , walletNodeTlsPrivKey    :: FilePath
     -- ^ A filepath to the TLS private key for the Node API.
+    , walletNodeTlsPublicKey  :: FilePath
+    -- ^ A filepath to the TLS public key for the Node API.
     , walletNodeTlsCaCertPath :: FilePath
     -- ^ A filepath to the TLS CA Certificate for communicating with the Node
     -- API.
@@ -90,6 +94,24 @@ getWalletDbOptions WalletBackendParams{..} =
 getFullMigrationFlag :: WalletBackendParams -> Bool
 getFullMigrationFlag WalletBackendParams{..} =
     forceFullMigration
+
+getNodeClientTlsParams :: WalletBackendParams -> TlsParams
+getNodeClientTlsParams WalletBackendParams {..} =
+    TlsParams
+        { tpCertPath = walletNodeTlsClientCert
+        , tpCaPath = walletNodeTlsCaCertPath
+        , tpKeyPath = walletNodeTlsPrivKey
+        , tpClientAuth = False
+        }
+
+getNodeServerTlsParams  :: WalletBackendParams -> TlsParams
+getNodeServerTlsParams WalletBackendParams {..} =
+    TlsParams
+        { tpCertPath = walletNodeTlsServerCert
+        , tpCaPath = walletNodeTlsCaCertPath
+        , tpKeyPath = walletNodeTlsPublicKey
+        , tpClientAuth = False
+        }
 
 -- | A richer type to specify in which mode we are running this node.
 data RunMode = ProductionMode
@@ -158,7 +180,9 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
                                                 <*> forceFullMigrationParser
                                                 <*> nodeAddressParser
                                                 <*> tlsClientCertPathParser
+                                                <*> tlsServerCertPathParser
                                                 <*> tlsPrivKeyParser
+                                                <*> tlsPublicKeyParser
                                                 <*> tlsCaCertPathParser
   where
     enableMonitoringApiParser :: Parser Bool
@@ -199,6 +223,15 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
             <> "the Node API."
             )
 
+    tlsServerCertPathParser :: Parser FilePath
+    tlsServerCertPathParser = strOption
+        $ long "node-tls-server-cert"
+        <> metavar "FILEPATH"
+        <> help
+            ( "Path to TLS client public certificate used to authenticate to "
+            <> "the Node API."
+            )
+
     tlsPrivKeyParser :: Parser FilePath
     tlsPrivKeyParser = strOption
         $ long "node-tls-key"
@@ -207,6 +240,16 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
             ( "Path to TLS client private key used to authenticate to the "
             <> "Node API."
             )
+
+    tlsPublicKeyParser :: Parser FilePath
+    tlsPublicKeyParser = strOption
+        $ long "node-tls-server-key"
+        <> metavar "FILEPATH"
+        <> help
+            ( "Path to TLS server public key used to authenticate to the "
+            <> "Node API."
+            )
+
 
     tlsCaCertPathParser :: Parser FilePath
     tlsCaCertPathParser = strOption

--- a/src/Cardano/Wallet/Server/CLI.hs
+++ b/src/Cardano/Wallet/Server/CLI.hs
@@ -26,14 +26,8 @@ import           Pos.Web (TlsParams (..))
 -- plus the wallet backend specific options.
 data WalletStartupOptions = WalletStartupOptions {
       wsoNodeArgs            :: !CommonNodeArgs
-    , wsoWalletBackendParams :: !ChooseWalletBackend
+    , wsoWalletBackendParams :: !WalletBackendParams
     } deriving Show
-
--- | TODO: Once we get rid of the legacy wallet, remove this.
-data ChooseWalletBackend =
-    WalletLegacy !WalletBackendParams
-  | WalletNew    !WalletBackendParams
-  deriving Show
 
 -- | DB-specific options.
 data WalletDBOptions = WalletDBOptions {
@@ -51,65 +45,23 @@ data WalletDBOptions = WalletDBOptions {
 -- Named with the suffix `Params` to honour other types of
 -- parameters like `NodeParams` or `SscParams`.
 data WalletBackendParams = WalletBackendParams
-    { enableMonitoringApi     :: !Bool
-    -- ^ Whether or not to run the monitoring API.
-    --
-    -- Note that this parameter is redundant, as we currently delegate to the
-    -- Node API and do not run a monitoring server anymore.
-    , monitoringApiPort       :: !Word16
-    -- ^ The port the monitoring API should listen to.
-    --
-    -- Note that this parameter is redundant, as we currently delegate to the
-    -- Node API and do not run a monitoring server anymore.
-    , walletTLSParams         :: !(Maybe TlsParams)
-    -- ^ The TLS parameters.
-    , walletAddress           :: !NetworkAddress
+    { walletTLSParams      :: !TlsParams
+    -- ^ The TLS parameters for the wallet server
+    , nodeTLSParams        :: !TlsParams
+    -- ^ The TLS parameters for the node server
+    , walletAddress        :: !NetworkAddress
     -- ^ The wallet address.
-    , walletDocAddress        :: !(Maybe NetworkAddress)
+    , walletDocAddress     :: !(Maybe NetworkAddress)
     -- ^ The wallet documentation address.
-    , walletRunMode           :: !RunMode
-    -- ^ The mode this node is running in.
-    , walletDbOptions         :: !WalletDBOptions
+    , walletDbOptions      :: !WalletDBOptions
     -- ^ DB-specific options.
-    , forceFullMigration      :: !Bool
-    , walletNodeAddress       :: !NetworkAddress
+    , forceFullMigration   :: !Bool
+    -- ^ Force non-lenient migration
+    , walletNodeAddress    :: !NetworkAddress
     -- ^ The IP address and port for the node backend.
-    , walletNodeTlsClientCert :: !FilePath
-    -- ^ A filepath to the Node's client certficate
-    , walletNodeTlsClientKey  :: !FilePath
-    -- ^ A filepath to the TLS private key for the Node API.
+    , walletNodeDocAddress :: !NetworkAddress
+    -- ^ The IP address and port for the node backend documentation
     } deriving Show
-
-getWalletDbOptions :: WalletBackendParams -> WalletDBOptions
-getWalletDbOptions WalletBackendParams{..} =
-    walletDbOptions
-
-getFullMigrationFlag :: WalletBackendParams -> Bool
-getFullMigrationFlag WalletBackendParams{..} =
-    forceFullMigration
-
-getNodeClientTlsParams :: WalletBackendParams -> Maybe TlsParams
-getNodeClientTlsParams WalletBackendParams{..} =
-    case walletTLSParams of
-        Nothing -> Nothing
-        Just p  -> Just $ TlsParams
-                        { tpCaPath = tpCaPath p
-                        , tpCertPath = walletNodeTlsClientCert
-                        , tpKeyPath = walletNodeTlsClientKey
-                        , tpClientAuth = tpClientAuth p
-                        }
-
--- | A richer type to specify in which mode we are running this node.
-data RunMode = ProductionMode
-             -- ^ Run in production mode
-             | DebugMode
-             -- ^ Run in debug mode
-             deriving Show
-
--- | Converts a @GenesisKeysInclusion@ into a @Bool@.
-isDebugMode :: RunMode -> Bool
-isDebugMode ProductionMode = False
-isDebugMode DebugMode      = True
 
 -- | Parses and returns the @WalletStartupOptions@ from the command line.
 getWalletNodeOptions :: HasCompileInfo => IO WalletStartupOptions
@@ -127,106 +79,70 @@ getWalletNodeOptions = execParser programInfo
 
 -- | The main @Parser@ for the @WalletStartupOptions@
 walletStartupOptionsParser :: Parser WalletStartupOptions
-walletStartupOptionsParser = WalletStartupOptions <$> CLI.commonNodeArgsParser
-                                                  <*> chooseWalletBackendParser
+walletStartupOptionsParser = WalletStartupOptions
+    <$> CLI.commonNodeArgsParser
+    <*> walletBackendParamsParser
 
--- | Choose between the two backends
---
--- TODO: This implementation of the parser is not very elegant. I'd prefer
--- something along the lines of
---
--- > chooseWalletBackendParser :: Parser ChooseWalletBackend
--- > chooseWalletBackendParser = asum [
--- >       WalletNew    <$> newWalletBackendParamsParser
--- >     , WalletLegacy <$> walletBackendParamsParser
--- >     ]
---
--- but for some reason this isn't working, perhaps because optparse-applicative
--- isn't backtracking enough? Dunno.
-chooseWalletBackendParser :: Parser ChooseWalletBackend
-chooseWalletBackendParser = choose
-    <$> walletBackendParamsParser
-    <*> (switch $ mconcat [
-            long "legacy-wallet"
-          , help "Use the legacy wallet implementation (NOT RECOMMENDED)"
-          ])
-  where
-    choose opts True  = WalletLegacy $ opts
-    choose opts False = WalletNew    $ opts
 
 -- | The @Parser@ for the @WalletBackendParams@.
 walletBackendParamsParser :: Parser WalletBackendParams
-walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
-                                                <*> monitoringApiPortParser
-                                                <*> tlsParamsParser
-                                                <*> walletAddressParser
-                                                <*> docAddressParser
-                                                <*> runModeParser
-                                                <*> dbOptionsParser
-                                                <*> forceFullMigrationParser
-                                                <*> nodeAddressParser
-                                                <*> tlsClientCertPathParser
-                                                <*> tlsClientKeyParser
+walletBackendParamsParser = mkWalletBackendParams
+    <$> (not <$> noClientAuthParser)
+    <*> caPathParser
+    <*> serverCertPathParser
+    <*> serverKeyPathParser
+    <*> clientCertPathParser
+    <*> clientKeyPathParser
+    <*> walletAddressParser
+    <*> docAddressParser
+    <*> dbOptionsParser
+    <*> forceFullMigrationParser
+    <*> nodeAddressParser
+    <*> nodeDocAddressParser
   where
-    enableMonitoringApiParser :: Parser Bool
-    enableMonitoringApiParser =
-        switch
-        ( long "monitoring-api"
-        <> help
-            ( "Activate the node monitoring API. This option doesn't do "
-            <> "anything anymore, as the monitoring API has been folded into "
-            <> "the API exposed by the node process."
+    -- NOTE
+    -- We do this to avoid having two flag for the CA cert and the --no-client-auth
+    -- (one for the wallet server and one for the node).
+    -- This way, we enforce, by construction, that they are the same.
+    mkWalletBackendParams auth caCrt srvCrt srvKey clCrt clKey =
+        WalletBackendParams
+            (TlsParams
+                { tpCertPath   = srvCrt
+                , tpCaPath     = caCrt
+                , tpKeyPath    = srvKey
+                , tpClientAuth = auth
+                }
             )
-        )
-
-    monitoringApiPortParser :: Parser Word16
-    monitoringApiPortParser = CLI.webPortOption 8080
-        $ "Port for the monitoring API. This option doesn't do anything "
-        <> "anymore, as the monitoring API has been folded into the API exposed"
-        <> "by the node process."
+            (TlsParams
+                { tpCertPath   = clCrt
+                , tpCaPath     = caCrt
+                , tpKeyPath    = clKey
+                , tpClientAuth = auth
+                }
+            )
 
     walletAddressParser :: Parser NetworkAddress
     walletAddressParser = networkAddrOption
-        $  long "wallet-address"
+        $  long "wallet-api-address"
         <> help "IP and port for backend wallet API."
         <> value (localhost, 8090)
 
     nodeAddressParser :: Parser NetworkAddress
     nodeAddressParser = networkAddrOption
-        $  long "wallet-node-api-address"
+        $  long "node-api-address"
         <> help "IP and port for underlying wallet's node monitoring API."
         <> value (localhost, 8080)
 
-    tlsClientCertPathParser :: Parser FilePath
-    tlsClientCertPathParser = strOption
-        $ long "node-tls-client-cert"
-        <> metavar "FILEPATH"
-        <> help
-            ( "Path to TLS client public certificate used to authenticate to "
-            <> "the Node API."
-            )
-
-
-    tlsClientKeyParser :: Parser FilePath
-    tlsClientKeyParser = strOption
-        $ long "node-tls-client-key"
-        <> metavar "FILEPATH"
-        <> help
-            ( "Path to TLS client private key used to authenticate to the "
-            <> "Node API."
-            )
+    nodeDocAddressParser :: Parser NetworkAddress
+    nodeDocAddressParser = networkAddrOption
+        $  long "node-doc-address"
+        <> help "IP and port for underlying wallet's node monitoring API Documentation."
+        <> value (localhost, 8180)
 
     docAddressParser :: Parser (Maybe NetworkAddress)
     docAddressParser = optional $ networkAddrOption
         $  long "wallet-doc-address"
         <> help "IP and port for backend wallet API documentation."
-
-    runModeParser :: Parser RunMode
-    runModeParser = (\debugMode -> if debugMode then DebugMode else ProductionMode) <$>
-        switch (long "wallet-debug" <>
-                help "Run wallet with debug params (e.g. include \
-                     \all the genesis keys in the set of secret keys)."
-               )
 
     forceFullMigrationParser :: Parser Bool
     forceFullMigrationParser = switch $
@@ -236,60 +152,49 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
                                \migration will stop and the node will crash, \
                                \instead of just logging the error."
 
-tlsParamsParser :: Parser (Maybe TlsParams)
-tlsParamsParser = constructTlsParams <$> certPathParser
-                                     <*> keyPathParser
-                                     <*> caPathParser
-                                     <*> (not <$> noClientAuthParser)
-                                     <*> disabledParser
-  where
-    constructTlsParams tpCertPath tpKeyPath tpCaPath tpClientAuth disabled =
-        guard (not disabled) $> TlsParams{..}
-
-    certPathParser :: Parser FilePath
-    certPathParser = strOption (CLI.templateParser
-                                "tlscert"
-                                "FILEPATH"
-                                "Path to file with TLS certificate"
-                                <> value "scripts/tls-files/server.crt"
-                               )
-
-    keyPathParser :: Parser FilePath
-    keyPathParser = strOption (CLI.templateParser
-                               "tlskey"
-                               "FILEPATH"
-                               "Path to file with TLS key"
-                               <> value "scripts/tls-files/server.key"
-                              )
-
     caPathParser :: Parser FilePath
-    caPathParser = strOption (CLI.templateParser
-                              "tlsca"
-                              "FILEPATH"
-                              "Path to file with TLS certificate authority"
-                              <> value "scripts/tls-files/ca.crt"
-                             )
+    caPathParser = strOption
+        $ long "tls-ca-cert"
+        <> metavar "FILEPATH"
+        <> help "Path to TLS CA public certificate which signed both wallet and node certificates"
 
     noClientAuthParser :: Parser Bool
     noClientAuthParser = switch $
-                         long "no-client-auth" <>
-                         help "Disable TLS client verification. If turned on, \
-                              \no client certificate is required to talk to \
-                              \the API."
+        long "tls-no-client-auth" <>
+        help "Disable TLS client verification. If turned on,\
+            \ no client certificate is required to talk to the API."
 
-    disabledParser :: Parser Bool
-    disabledParser = switch $
-                     long "no-tls" <>
-                     help "Disable tls. If set, 'tlscert', 'tlskey' \
-                          \and 'tlsca' options are ignored"
+    serverCertPathParser :: Parser FilePath
+    serverCertPathParser = strOption
+        $ long "tls-wallet-server-cert"
+        <> metavar "FILEPATH"
+        <> help "Path to TLS server public certificate used to identify the wallet server"
 
+    serverKeyPathParser :: Parser FilePath
+    serverKeyPathParser = strOption
+        $ long "tls-wallet-server-key"
+        <> metavar "FILEPATH"
+        <> help "Path to TLS server private key used to identify the wallet server"
+
+    clientCertPathParser :: Parser FilePath
+    clientCertPathParser = strOption
+        $ long "tls-node-client-cert"
+        <> metavar "FILEPATH"
+        <> help "Path to TLS client public certificate used to authenticate to the node server"
+
+    clientKeyPathParser :: Parser FilePath
+    clientKeyPathParser = strOption
+        $ long "tls-node-client-key"
+        <> metavar "FILEPATH"
+        <> help "Path to TLS client private key used to authenticate to the node server"
 
 -- | The parser for the @WalletDBOptions@.
 dbOptionsParser :: Parser WalletDBOptions
-dbOptionsParser = WalletDBOptions <$> dbPathParser
-                                  <*> rebuildDbParser
-                                  <*> acidIntervalParser
-                                  <*> flushDbParser
+dbOptionsParser = WalletDBOptions
+    <$> dbPathParser
+    <*> rebuildDbParser
+    <*> acidIntervalParser
+    <*> flushDbParser
   where
     dbPathParser :: Parser FilePath
     dbPathParser = strOption (long  "wallet-db-path" <>

--- a/src/Cardano/Wallet/Server/CLI.hs
+++ b/src/Cardano/Wallet/Server/CLI.hs
@@ -181,8 +181,8 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
                                                 <*> nodeAddressParser
                                                 <*> tlsClientCertPathParser
                                                 <*> tlsServerCertPathParser
-                                                <*> tlsPrivKeyParser
-                                                <*> tlsPublicKeyParser
+                                                <*> tlsClientKeyParser
+                                                <*> tlsServerKeyParser
                                                 <*> tlsCaCertPathParser
   where
     enableMonitoringApiParser :: Parser Bool
@@ -232,8 +232,8 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
             <> "the Node API."
             )
 
-    tlsPrivKeyParser :: Parser FilePath
-    tlsPrivKeyParser = strOption
+    tlsClientKeyParser :: Parser FilePath
+    tlsClientKeyParser = strOption
         $ long "node-tls-key"
         <> metavar "FILEPATH"
         <> help
@@ -241,8 +241,8 @@ walletBackendParamsParser = WalletBackendParams <$> enableMonitoringApiParser
             <> "Node API."
             )
 
-    tlsPublicKeyParser :: Parser FilePath
-    tlsPublicKeyParser = strOption
+    tlsServerKeyParser :: Parser FilePath
+    tlsServerKeyParser = strOption
         $ long "node-tls-server-key"
         <> metavar "FILEPATH"
         <> help

--- a/src/Cardano/Wallet/Server/Plugins.hs
+++ b/src/Cardano/Wallet/Server/Plugins.hs
@@ -229,7 +229,7 @@ nodeAPIServer
     nodeResources
     diffusion
   = withCompileInfo $ do
-    logInfo $ "Launching the node api server"
+    logInfo $ "Launching the node api server with tls params: " <> (show tls)
 
     let apiArgs = walletToNodeArgs walletParams
 

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -30,7 +30,7 @@ main = do
         , ("relay", NodeRelay)
         , ("edge", NodeEdge)
         ]
-    let wAddr   = toBaseUrl $ env ! "WALLET_ADDRESS"
+    let wAddr   = toBaseUrl $ env ! "WALLET_API_ADDRESS"
     let dAddr   = toBaseUrl $ env ! "WALLET_DOC_ADDRESS"
     let wClient = mkHttpClient wAddr manager
     let dClient = mkHttpDocClient dAddr manager

--- a/test/integration/Test/Integration/Framework/Cluster.hs
+++ b/test/integration/Test/Integration/Framework/Cluster.hs
@@ -63,12 +63,14 @@ defaultIntegrationEnv = Map.fromList
     , ("WALLET_DOC_ADDRESS", "127.0.0.1:8190")
     , ("WALLET_DB_PATH", "./state-integration/wallet-db/edge")
     , ("WALLET_REBUILD_DB", "True")
-    , ("WALLET_NODE_API_ADDRESS", "127.0.0.1:8089")
-    , ("NODE_API_ADDRESS", "127.0.0.1:8086")
+    , ("WALLET_NODE_API_ADDRESS", "127.0.0.1:8185")
+    , ("NODE_API_ADDRESS", "127.0.0.1:8080")
     , ("NODE_DOC_ADDRESS", "127.0.0.1:3186")
-    , ("NODE_TLS_CLIENT_CERT", "./state-integration/tls/relay/client.crt")
-    , ("NODE_TLS_KEY", "./state-integration/tls/relay/client.key")
-    , ("NODE_TLS_CA_CERT", "./state-integration/tls/relay/ca.crt")
+    , ("NODE_TLS_CLIENT_CERT", "./state-integration/tls/edge/client.crt")
+    , ("NODE_TLS_KEY", "./state-integration/tls/edge/client.key")
+    , ("NODE_TLS_CA_CERT", "./state-integration/tls/edge/ca.crt")
+    , ("NODE_TLS_SERVER_CERT", "./state-integration/tls/edge/server.crt")
+    , ("NODE_TLS_SERVER_KEY", "./state-integration/tls/edge/server.key")
     ]
 
 -- | Start an integration cluster. Quite identical to the original "start cluster".

--- a/test/integration/Test/Integration/Framework/Cluster.hs
+++ b/test/integration/Test/Integration/Framework/Cluster.hs
@@ -67,10 +67,7 @@ defaultIntegrationEnv = Map.fromList
     , ("NODE_API_ADDRESS", "127.0.0.1:8080")
     , ("NODE_DOC_ADDRESS", "127.0.0.1:3186")
     , ("NODE_TLS_CLIENT_CERT", "./state-integration/tls/edge/client.crt")
-    , ("NODE_TLS_KEY", "./state-integration/tls/edge/client.key")
-    , ("NODE_TLS_CA_CERT", "./state-integration/tls/edge/ca.crt")
-    , ("NODE_TLS_SERVER_CERT", "./state-integration/tls/edge/server.crt")
-    , ("NODE_TLS_SERVER_KEY", "./state-integration/tls/edge/server.key")
+    , ("NODE_TLS_CLIENT_KEY", "./state-integration/tls/edge/client.key")
     ]
 
 -- | Start an integration cluster. Quite identical to the original "start cluster".

--- a/test/integration/Test/Integration/Framework/Cluster.hs
+++ b/test/integration/Test/Integration/Framework/Cluster.hs
@@ -59,15 +59,15 @@ defaultIntegrationEnv = Map.fromList
     , ("CONFIGURATION_KEY", "default")
     , ("STATE_DIR", "./state-integration")
     , ("REBUILD_DB", "True")
-    , ("WALLET_ADDRESS", "127.0.0.1:8090")
-    , ("WALLET_DOC_ADDRESS", "127.0.0.1:8190")
-    , ("WALLET_DB_PATH", "./state-integration/wallet-db/edge")
     , ("WALLET_REBUILD_DB", "True")
-    , ("WALLET_NODE_API_ADDRESS", "127.0.0.1:8185")
-    , ("NODE_API_ADDRESS", "127.0.0.1:8080")
-    , ("NODE_DOC_ADDRESS", "127.0.0.1:3186")
-    , ("NODE_TLS_CLIENT_CERT", "./state-integration/tls/edge/client.crt")
-    , ("NODE_TLS_CLIENT_KEY", "./state-integration/tls/edge/client.key")
+    , ("WALLET_DB_PATH", "./state-integration/wallet-db/edge")
+    , ("WALLET_API_ADDRESS", "127.0.0.1:8090")
+    , ("WALLET_DOC_ADDRESS", "127.0.0.1:8190")
+    , ("TLS_CA_CERT", "./state-integration/tls/edge/ca.crt")
+    , ("TLS_WALLET_SERVER_CERT", "./state-integration/tls/edge/server.crt")
+    , ("TLS_WALLET_SERVER_KEY", "./state-integration/tls/edge/server.key")
+    , ("TLS_NODE_CLIENT_CERT", "./state-integration/tls/edge/client.crt")
+    , ("TLS_NODE_CLIENT_KEY", "./state-integration/tls/edge/client.key")
     ]
 
 -- | Start an integration cluster. Quite identical to the original "start cluster".
@@ -203,8 +203,12 @@ printCartouche :: Env -> IO ()
 printCartouche env = do
     let colSize = 35
     putTextLn $ toText (env ! "NODE_ID") <> T.replicate (colSize - length (env !  "NODE_ID")) "-"
-    when (Map.member "LISTEN" env) $ putTextLn $  "|.....listen:        " <> toText (env ! "LISTEN")
-    putTextLn $ "|.....api address:   " <> toText (env ! "NODE_API_ADDRESS")
-    putTextLn $ "|.....doc address:   " <> toText (env ! "NODE_DOC_ADDRESS")
-    putTextLn $ "|.....system start:  " <> toText (env ! "SYSTEM_START")
+    safeLine "LISTEN"           "|.....listen:        "
+    safeLine "NODE_API_ADDRESS" "|.....api address:   "
+    safeLine "NODE_DOC_ADDRESS" "|.....doc address:   "
+    safeLine "SYSTEM_START"     "|.....system start:  "
     putTextLn $ T.replicate colSize "-" <> "\n"
+  where
+    safeLine :: String -> Text -> IO ()
+    safeLine k title =
+        when (Map.member k env) $ putTextLn $ title <> toText (env ! k)


### PR DESCRIPTION
Previously we launched a client expecting a node monitoring api server
to be running, without actually starting the server. The integration
tests still worked, as we connect to the api of a relay node.

This commit adds a wallet `Plugin` for starting the node server, as well
as CLI options for its tls settings for starting the node server, as
well as CLI options for its tls settings.

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#87</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `Plugin` for launching node monitoring api server
- [x] Added CLI param ` --node-tls-server-cert            ./state-integration/tls/edge/server.crt`
- [x] Added CLI param `--node-tls-server-key             ./state-integration/tls/edge/server.key`


# Comments

- [ ] Will need to update wiki
- [ ] Have not reused wallet and node tls params. Maybe I should
- [ ] Naming of CLI params should be looked at (I might have messed it up completely)

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->