### PR TITLE
preserve query and fragment part of the URI while redirecting for relative paths (swagger doc)

### DIFF
--- a/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -1061,8 +1061,8 @@ swaggerSchemaUIServer =
     <script>
         // Force Strict-URL Routing for assets relative paths
         (function onload() {
-            if (!window.location.href.endsWith("/")) {
-                window.location.href += "/";
+            if (!window.location.pathname.endsWith("/")) {
+                window.location.pathname += "/";
             }
         }());
     </script>


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#299</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have modified the `pathname` rather than the whole `href` to preserve URI fragment (and query params) 
- [ ] This still works us around the access of assets using relative path and, preserve the quite useful deep-linking feature of the API doc 

# Comments

<!-- Additional comments or screenshots to attach if any -->

This is roughly what a `location` object looks like in the DOM. So, modifying the `href` was a bit wrong in the sense that it completely breaks the whole `fragment` used by the underlying React app to route the request and perform deeplinking accordingly.

```js
{ hash: ""
, host: "github.com"
, hostname: "github.com"
, href: "https://github.com/input-output-hk/cardano-wallet/compare/KtorZ/299/deeplink-api-doc?expand=1"
, origin: "https://github.com"
, pathname: "/input-output-hk/cardano-wallet/compare/KtorZ/299/deeplink-api-doc"
, port: ""
, protocol: "https:"
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
