### PR TITLE
Add more meaningful comments to `TransactionDirection`.

### DIFF
--- a/src/Cardano/Wallet/API/V1/Types.hs
+++ b/src/Cardano/Wallet/API/V1/Types.hs
@@ -1715,9 +1715,9 @@ instance BuildableSafeGen TransactionType where
 -- | The 'Transaction' @direction@
 data TransactionDirection =
     IncomingTransaction
-  -- ^ This represents an incoming transactions.
+  -- ^ Represents a transaction that adds funds to the local wallet.
   | OutgoingTransaction
-  -- ^ This qualifies external transactions.
+  -- ^ Represents a transaction that removes funds from the local wallet.
   deriving (Show, Ord, Eq, Enum, Bounded)
 
 instance Arbitrary TransactionDirection where


### PR DESCRIPTION
The existing comments merely repeat the constructor names. This change provides more information about what each constructor represents.