### PR TITLE
Do not generate and re-generate genesis keys multiple times if they already exists

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -587,6 +587,7 @@ test-suite integration
     , cardano-wallet
     , containers
     , cryptonite
+    , directory
     , filepath
     , generic-lens
     , hspec


### PR DESCRIPTION

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#236</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have made our life a little easier by speeding up the initial start-time of integration tests

# Comments

<!-- Additional comments or screenshots to attach if any -->

It actually takes a significant amount of time to generate hundreds of private keys and dumb avvm certificates. Especially because we do it three times, one for each core node.

This commits prevent that, speeding up the initial starting time for integration tests by 30 to 60s depending on the machine, which is not much, but matters when we run them 50 times a day. 

When starting integration tests from scratch we now see the following (minus the logger exceptions that no one still has fixed on -sl):

```
cardano-wallet-2.0.0: test (suite: integration, args: --match patate)

Starting cluster of nodes... ╰( ͡° ͜ʖ ͡° )つ──☆*:・ﾟ
Suggestion: tail -F ./state-integration/logs/edge.log.pub
WARNING (core1): not generating new keys in './state-integration/generated-keys' because the directory already exists.
WARNING (core2): not generating new keys in './state-integration/generated-keys' because the directory already exists.
```

So, when generating the environment for the first core node, we do indeed generate the corresponding keys. And not do it again for the other core nodes. Moreover when re-running test (and keeping an existing state-intregration directory), we just skip it for all core nodes. 

```
cardano-wallet-2.0.0: test (suite: integration)
            
Starting cluster of nodes... ╰( ͡° ͜ʖ ͡° )つ──☆*:・ﾟ
Suggestion: tail -F ./state-integration/logs/edge.log.pub
WARNING (core0): not generating new keys in './state-integration/generated-keys' because the directory already exists.
WARNING (core1): not generating new keys in './state-integration/generated-keys' because the directory already exists.
WARNING (core2): not generating new keys in './state-integration/generated-keys' because the directory already exists.
```

Special note also: genesis keys are generated completely generically (which is always what allows us to have hard-coded redemption codes in the integration tests!), so re-generating the same thing over and over is just a waste of time and energy.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
