### PR TITLE
Retry when checking node api connection

### DIFF
--- a/src/Cardano/Wallet/Server/Plugins.hs
+++ b/src/Cardano/Wallet/Server/Plugins.hs
@@ -51,6 +51,7 @@ import qualified Cardano.Wallet.API.V1.Types as V1
 import           Cardano.Wallet.Kernel (DatabaseMode (..), PassiveWallet)
 import qualified Cardano.Wallet.Kernel.Diffusion as Kernel
 import qualified Cardano.Wallet.Kernel.Mode as Kernel
+import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as NodeStateAdaptor
 import qualified Cardano.Wallet.Server as Server
 import           Cardano.Wallet.Server.CLI (WalletBackendParams (..),
                      WalletBackendParams (..), walletAcidInterval,
@@ -101,7 +102,7 @@ apiServer
     env <- ask
     let diffusion' = Kernel.fromDiffusion (lower env) diffusion
     logInfo "Testing node client connection"
-    eresp <- liftIO . runExceptT $ NodeClient.getNodeSettings nodeClient
+    eresp <- liftIO . NodeStateAdaptor.retrying . runExceptT $ NodeClient.getNodeSettings nodeClient
     case eresp of
         Left err -> do
             logError


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#87</p>

# Context

When starting a wallet we would see
```
[2019-02-06 11:08:25.49 UTC] There was an error connecting to the node: ErrFromServant (ConnectionError "HttpExceptionRequest Request {\n  host                 = \"127.0.0.1\"\n  port                 = 8080\n  secure               = True\n  requestHeaders       = [(\"Accept\",\"application/json;charset=utf-8,application/json\")]\n  path                 = \"/api/v1/node-settings\"\n  queryString          = \"\"\n  method               = \"GET\"\n  proxy                = Nothing\n  rawBody              = False\n  redirectCount        = 10\n  responseTimeout      = ResponseTimeoutDefault\n  requestVersion       = HTTP/1.1\n}\n (InternalException (HostCannotConnect \"127.0.0.1\" [Network.Socket.connect: <socket: 49>: does not exist (Connection refused)]))")
```

In the logs from https://github.com/input-output-hk/cardano-wallet/blob/3d769cff56bc754d2355cdb8369858f67e2ff892/src/Cardano/Wallet/Server/Plugins.hs#L103-L111

as the server hadn't started yet.

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have exported `retrying` in the `NodeStateAdaptor` module
- [x] Used this `retrying` when checking node client connection on startup
- [x] We no longer get an error logged about the node connection having failed


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->