### PR TITLE
Do not require an account id for importing addresses

### DIFF
--- a/src/Cardano/Wallet/API/V1/Addresses.hs
+++ b/src/Cardano/Wallet/API/V1/Addresses.hs
@@ -19,7 +19,7 @@ type API = Tag "Addresses" 'NoTagDescription :>
       :<|> "addresses" :> Capture "address" Text
                        :> Summary "Returns interesting information about an address, if available and valid."
                        :> Get '[ValidJSON] (APIResponse WalletAddress)
-      :<|> "wallets" :> CaptureWalletId :> "accounts" :> CaptureAccountId :> "addresses"
+      :<|> "wallets" :> CaptureWalletId :> "addresses"
         :> Summary "Batch import existing addresses"
         :> ReqBody '[ValidJSON] [WalAddress]
         :> Post '[ValidJSON] (APIResponse (BatchImportResult WalAddress))

--- a/src/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/src/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -55,11 +55,10 @@ getAddress pwl addressRaw = do
 importAddresses
     :: PassiveWalletLayer IO
     -> WalletId
-    -> AccountIndex
     -> [WalAddress]
     -> Handler (APIResponse (BatchImportResult WalAddress))
-importAddresses pwl walId accIx addrs = do
-    res <- liftIO $ WalletLayer.importAddresses pwl walId accIx addrs
+importAddresses pwl walId addrs = do
+    res <- liftIO $ WalletLayer.importAddresses pwl walId addrs
     case res of
         Left err   -> throwM err
         Right res' -> return $ single res'

--- a/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -1002,7 +1002,7 @@ derivation, it is unlikely that the same addresses will be generated on two
 different node instances. However, some API users may wish to preserve unused
 addresses between different instances of the wallet backend.
 
-To enable this, the wallet backend provides an endpoint ([`POST /api/v1/wallets/{{walletId}}/accounts/{{accountId}/addresses`](#tag/Addresses%2Fpaths%2F~1api~1v1~1wallets~1{walletId}~1accounts~1{accountId}~1addresses%2Fpost))
+To enable this, the wallet backend provides an endpoint ([`POST /api/v1/wallets/{{walletId}}/addresses`](#tag/Addresses%2Fpaths%2F~1api~1v1~1wallets~1{walletId}~1addresses%2Fpost))
 to import a list of addresses into a given account. Note that this endpoint is
 quite lenient when it comes to errors: it tries to import all provided addresses
 one by one, and ignores any that can't be imported for whatever reason. The
@@ -1014,7 +1014,7 @@ For example:
 
 ```
 curl -X POST \
-  https://127.0.0.1:8090/api/v1/wallets/Ae2tdPwUPE...8V3AVTnqGZ/accounts/2147483648/addresses \
+  https://127.0.0.1:8090/api/v1/wallets/Ae2tdPwUPE...8V3AVTnqGZ/addresses \
   -H 'Accept: application/json;charset=utf-8' \
   --cacert ./scripts/tls-files/ca.crt \
   --cert ./scripts/tls-files/client.pem \

--- a/src/Cardano/Wallet/Client.hs
+++ b/src/Cardano/Wallet/Client.hs
@@ -78,7 +78,6 @@ data WalletClient m
          :: Text -> Resp m WalletAddress
     , importAddresses
         :: WalletId
-        -> AccountIndex
         -> [WalAddress]
         -> Resp m (BatchImportResult WalAddress)
     -- wallets endpoints
@@ -246,7 +245,7 @@ natMapClient phi f wc = WalletClient
     , getAddress =
         f . phi . getAddress wc
     , importAddresses =
-        \x y -> f . phi . importAddresses wc x y
+        \x -> f . phi . importAddresses wc x
     , postWallet =
         f . phi . postWallet wc
     , getWalletIndexFilterSorts =

--- a/src/Cardano/Wallet/Client/Http.hs
+++ b/src/Cardano/Wallet/Client/Http.hs
@@ -43,7 +43,7 @@ mkHttpClient baseUrl manager = WalletClient
     , getAddress
         = run . getAddressR
     , importAddresses
-        = \x y -> run . importAddressesR x y
+        = \x -> run . importAddressesR x
     -- wallets endpoints
     , postWallet
         = run . postWalletR

--- a/src/Cardano/Wallet/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/Kernel/Addresses.hs
@@ -187,8 +187,8 @@ newHdAddress nm esk spendingPassword accId hdAddressId =
 
 
 data ImportAddressError
-    = ImportAddressKeystoreNotFound HdAccountId
-    -- ^ When trying to create the 'Address', the parent 'Account' was not there.
+    = ImportAddressKeystoreNotFound HdRootId
+    -- ^ When trying to import the 'Address', the parent root was not there.
     deriving Eq
 
 instance Arbitrary ImportAddressError where
@@ -198,8 +198,8 @@ instance Arbitrary ImportAddressError where
 
 instance Buildable ImportAddressError where
     build = \case
-        ImportAddressKeystoreNotFound uAccount ->
-            bprint ("ImportAddressError" % F.build) uAccount
+        ImportAddressKeystoreNotFound rootId ->
+            bprint ("ImportAddressError" % F.build) rootId
 
 instance Show ImportAddressError where
     show = formatToString build
@@ -212,24 +212,22 @@ instance Show ImportAddressError where
 -- no guarantee that addresses would be generated in the same order on a new
 -- node (they better not actually!).
 importAddresses
-    :: HdAccountId
-    -- ^ An abstract notion of an 'Account' identifier
+    :: HdRootId
     -> [Address]
     -> PassiveWallet
     -> IO (Either ImportAddressError [Either Address ()])
-importAddresses accId addrs pw = runExceptT $ do
-    let rootId = accId ^. hdAccountIdParent
+importAddresses rootId addrs pw = runExceptT $ do
     esk <- lookupSecretKey rootId
     lift $ forM addrs (flip importOneAddress [(rootId, esk)])
   where
     lookupSecretKey
         :: HdRootId
         -> ExceptT ImportAddressError IO EncryptedSecretKey
-    lookupSecretKey rootId = do
+    lookupSecretKey k = do
         let nm = makeNetworkMagic (pw ^. walletProtocolMagic)
         let keystore = pw ^. walletKeystore
-        lift (Keystore.lookup nm rootId keystore) >>= \case
-            Nothing  -> throwError (ImportAddressKeystoreNotFound accId)
+        lift (Keystore.lookup nm k keystore) >>= \case
+            Nothing  -> throwError (ImportAddressKeystoreNotFound rootId)
             Just esk -> return esk
 
     importOneAddress

--- a/src/Cardano/Wallet/WalletLayer.hs
+++ b/src/Cardano/Wallet/WalletLayer.hs
@@ -497,7 +497,6 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , validateAddress      :: Text
                            -> m (Either ValidateAddressError WalletAddress)
     , importAddresses      :: WalletId
-                           -> AccountIndex
                            -> [WalAddress]
                            -> m (Either ImportAddressError (BatchImportResult WalAddress))
 

--- a/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
+++ b/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
@@ -191,14 +191,13 @@ importAddresses
     :: (MonadIO m)
     => Kernel.PassiveWallet
     -> V1.WalletId
-    -> V1.AccountIndex
     -> [V1.WalAddress]
     -> m (Either ImportAddressError (V1.BatchImportResult V1.WalAddress))
-importAddresses wallet wId accIx addrs = runExceptT $ do
-    accId <- withExceptT ImportAddressAddressDecodingFailed $
-        fromAccountId wId accIx
+importAddresses wallet wId addrs = runExceptT $ do
+    rootId <- withExceptT ImportAddressAddressDecodingFailed $
+        fromRootId wId
     res <- withExceptT ImportAddressError $ ExceptT $ liftIO $
-        Kernel.importAddresses accId (V1.unWalAddress <$> addrs) wallet
+        Kernel.importAddresses rootId (V1.unWalAddress <$> addrs) wallet
     return $ foldImportResults V1.WalAddress res
   where
     foldImportResults

--- a/test/integration/Test/Integration/Scenario/Addresses.hs
+++ b/test/integration/Test/Integration/Scenario/Addresses.hs
@@ -27,7 +27,7 @@ spec = do
         fixture <- setup defaultSetup
         addr <- successfulRequest $ Client.postAddress $- NewAddress
             Nothing
-            minBound
+            defaultAccountId
             (fixture ^. wallet . walletId)
         void $ successfulRequest $ Client.deleteWallet $- (fixture ^. wallet . walletId)
         void $ successfulRequest $ Client.postWallet $- NewWallet
@@ -39,7 +39,6 @@ spec = do
 
         response <- request $ Client.importAddresses
             $- fixture ^. wallet . walletId
-            $- defaultAccountId
             $- [view address addr]
 
         verify response
@@ -59,7 +58,6 @@ spec = do
 
         response <- request $ Client.importAddresses
             $- ourFixture ^. wallet . walletId
-            $- defaultAccountId
             $- addrs
         index <- fmap (fmap accAddresses) $ request $ Client.getAccount
             $- ourFixture ^. wallet . walletId
@@ -94,7 +92,6 @@ spec = do
 
         response <- request $ Client.importAddresses
             $- fixture ^. wallet . walletId
-            $- defaultAccountId
             $- map (view address) addrs
 
         verify response

--- a/test/manual/258/scenarios.md
+++ b/test/manual/258/scenarios.md
@@ -1,10 +1,8 @@
-
-
 # Context
 
 This document describes manual test procedure for https://github.com/input-output-hk/cardano-wallet/issues/258. 
 
-The change here introduces new endpoint `POST /api/v1/wallets/{wid}/accounts/{accix}/addresses` which allows batch import of unused addresses into the wallet's account. This functionality is targeted to exchanges and the possible use case has been described in the Wallet's API documentation https://input-output-hk.github.io/cardano-wallet/#section/Common-Use-Cases/Importing-(Unused)-Addresses-From-a-Previous-Node-(or-Version).
+The change here introduces new endpoint `POST /api/v1/wallets/{wid}/addresses` which allows batch import of unused addresses into the wallet's account. This functionality is targeted to exchanges and the possible use case has been described in the Wallet's API documentation https://input-output-hk.github.io/cardano-wallet/#section/Common-Use-Cases/Importing-(Unused)-Addresses-From-a-Previous-Node-(or-Version).
 
 There have been automated integration tests added for testing new endpoint however there are still areas that need to be tested manually as they cannot be easily instrumented using integration tests. These are:
  - doing batch import of addresses while wallet is being restored

--- a/test/manual/scripts/import-addresses.sh
+++ b/test/manual/scripts/import-addresses.sh
@@ -15,8 +15,6 @@
 #
 # Options:
 #   -h --help
-#   -a --account=INT         An optional parent account index [default: 2147483648]
-#   -n --number=INT          number of addresses to generate [default: 10]
 #   -p --port=INT            Port the server is listening to [default: 8090]
 #   -c --client=FILEPATH     TLS client certificate expected by the server [default: ../../../state-staging/tls/client/client.pem]
 #
@@ -26,7 +24,7 @@
 
 PATH=.:$PATH; source docopts.sh --auto "$@"
 
-curl -kX POST https://localhost:${ARGS[--port]}/api/v1/wallets/${ARGS[<wallet_id>]}/accounts/${ARGS[--account]}/addresses \
+curl -kX POST https://localhost:${ARGS[--port]}/api/v1/wallets/${ARGS[<wallet_id>]}/addresses \
   -H "Accept: application/json; charset=utf-8" \
   -H "Content-Type: application/json; charset=utf-8" \
   --cert ${ARGS[--client]} \

--- a/test/unit/Golden/golden/api-layout.txt
+++ b/test/unit/Golden/golden/api-layout.txt
@@ -25,10 +25,8 @@
 │  └─•
 └─ wallets/
    ├─ <capture>/
-   │  └─ accounts/
-   │     └─ <capture>/
-   │        └─ addresses/
-   │           └─•
+   │  └─ addresses/
+   │     └─•
    ┆
    ├─•
    ┆


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#258</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have remove the 'accountIndex' from the import-address endpoint


# Comments

<!-- Additional comments or screenshots to attach if any -->

Actually, we were sort-of ignoring it already and the endpoint was misleading.
Cardano addresses embed their corresponding account index inside them, therefore,
when importing addresses, we only care about the root master key (and therefore, the
root id). The account ix comes from the address anyway


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
