### PR TITLE
Enforce a non-empty list of accounts when creating a externally-owned wallet

### DIFF
--- a/src/Cardano/Wallet/API/V1/Types.hs
+++ b/src/Cardano/Wallet/API/V1/Types.hs
@@ -148,6 +148,7 @@ import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
 import qualified Data.Char as C
 import           Data.Default (Default (def))
+import qualified Data.List.NonEmpty as NE
 import           Data.Semigroup (Semigroup)
 import           Data.Swagger hiding (Example, example)
 import           Data.Text (Text, dropEnd, toLower)
@@ -1181,13 +1182,13 @@ instance BuildableSafeGen AccountPublicKeyWithIx where
         accpubkeywithixPublicKey
         accpubkeywithixIndex
 
-instance Buildable [AccountPublicKeyWithIx] where
-    build = bprint listJson
+instance Buildable (NonEmpty AccountPublicKeyWithIx) where
+    build = bprint listJson . NE.toList
 
 -- | A type modelling the request for a new 'EosWallet',
 -- on the mobile client or hardware wallet.
 data NewEosWallet = NewEosWallet
-    { neweoswalAccounts       :: ![AccountPublicKeyWithIx]
+    { neweoswalAccounts       :: !(NonEmpty AccountPublicKeyWithIx)
     , neweoswalAddressPoolGap :: !(Maybe AddressPoolGap)
     , neweoswalAssuranceLevel :: !AssuranceLevel
     , neweoswalName           :: !WalletName

--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Kernel.Wallets (
 import qualified Prelude
 import           Universum
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Formatting (bprint, build, formatToString, (%))
 import qualified Formatting as F
@@ -228,7 +229,7 @@ createHdWallet pw mnemonic spendingPassword assuranceLevel walletName = do
 -- for each account at will and discovered using the address pool discovery algorithm
 -- described in BIP-44. Public keys are managed and provided from an external sources.
 createEosHdWallet :: PassiveWallet
-                  -> [(PublicKey, HdAccountIx)]
+                  -> NonEmpty (PublicKey, HdAccountIx)
                   -- ^ External wallets' accounts
                   -> AddressPoolGap
                   -- ^ Address pool gap for this wallet.
@@ -242,7 +243,7 @@ createEosHdWallet :: PassiveWallet
                   -> IO (Either CreateWalletError HdRoot)
 createEosHdWallet pw accounts gap assuranceLevel walletName = do
     root <- initHdRoot' <$> HD.genHdRootId <*> getCurrentTimestamp
-    let bases = Map.unionsWith (<>) (toAccountBase (root ^. hdRootId) <$> accounts)
+    let bases = Map.unionsWith (<>) (NE.toList (toAccountBase (root ^. hdRootId) <$> accounts))
     res <- update' (pw ^. wallets) $ CreateHdWallet root bases
     return $ case res of
         Left e@(HD.CreateHdRootExists _) ->

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -20,22 +20,23 @@ module Test.Integration.Framework.DSL
     , verify
 
     -- * Requests (Only API types)
-    , NewAddress(..)
-    , NewWallet (..)
+    , AddressPoolGap
+    , AssuranceLevel(..)
+    , DestinationChoice(..)
+    , EosWallet(..)
+    , FilterOperations(..)
     , NewAccount (..)
+    , NewAddress(..)
     , NewEosWallet (..)
+    , NewWallet (..)
     , PasswordUpdate (..)
     , Payment (..)
     , RawPassword (..)
     , Redemption (..)
-    , WalletUpdate(..)
     , ShieldedRedemptionCode (..)
-    , FilterOperations(..)
     , SortOperations(..)
     , WalletOperation(..)
-    , AssuranceLevel(..)
-    , DestinationChoice(..)
-    , AddressPoolGap
+    , WalletUpdate(..)
     , defaultAccountId
     , defaultAssuranceLevel
     , defaultDistribution


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#236</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have forbidden creation of E.O. wallets with a empty list of accounts


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
