### PR TITLE
Map Kernel import address errors to API errors

### DIFF
--- a/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -34,6 +34,7 @@ translateWalletLayerErrors :: SomeException -> Maybe V1.WalletError
 translateWalletLayerErrors ex = do
        (    try' @CreateAddressError createAddressError
         <|> try' @ValidateAddressError validateAddressError
+        <|> try' @ImportAddressError importAddressError
 
         <|> try' @CreateAccountError createAccountError
         <|> try' @GetAccountError getAccountError
@@ -60,7 +61,12 @@ translateWalletLayerErrors ex = do
   where try' :: forall e. Exception e => (e -> V1.WalletError) -> Maybe V1.WalletError
         try' f = f <$> fromException @e ex
 
-
+importAddressError :: ImportAddressError -> V1.WalletError
+importAddressError e = case e of
+    (ImportAddressError (Kernel.ImportAddressKeystoreNotFound _)) ->
+        V1.WalletNotFound
+    (ImportAddressAddressDecodingFailed _) ->
+        V1.WalletNotFound
 
 createAddressErrorKernel :: Kernel.CreateAddressError -> V1.WalletError
 createAddressErrorKernel e = case e of


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#258</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have map import-address kernel errors to API errors 

# Comments

<!-- Additional comments or screenshots to attach if any -->

```
 $ curl -vkX POST "https://localhost:8090/api/v1/wallets/123/addresses" \
    --cert state-integration/tls/edge/client.pem   \
    -H "Content-Type: application/json" \ 
    -d '[]'

< HTTP/1.1 404 Reference to an unexisting wallet was given.

{"status":"error","diagnostic":{},"message":"WalletNotFound"}
```


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
