### PR TITLE
Always close the acid state DB

### DIFF
--- a/src/Cardano/Wallet/Kernel.hs
+++ b/src/Cardano/Wallet/Kernel.hs
@@ -27,8 +27,8 @@ module Cardano.Wallet.Kernel (
 import           Universum hiding (State)
 
 import           Control.Concurrent.Async (async, cancel)
-import           Data.Acid (AcidState, createArchive, createCheckpoint,
-                     openLocalStateFrom)
+import           Data.Acid (AcidState, closeAcidState, openLocalStateFrom)
+import           Data.Acid.Local (createCheckpointAndClose)
 import           Data.Acid.Memory (openMemoryState)
 import qualified Data.Map.Strict as Map
 import           System.Directory (doesPathExist, removePathForcibly)
@@ -142,10 +142,9 @@ handlesClose dbMode (Handles acidDb meta) = do
     closeMetaDB meta
     case dbMode of
         UseInMemory ->
-            pure ()
-        UseFilePath DatabaseOptions{} -> do
-            createCheckpoint acidDb
-            createArchive acidDb
+            closeAcidState acidDb
+        UseFilePath DatabaseOptions{} ->
+            createCheckpointAndClose acidDb
 
 {-------------------------------------------------------------------------------
   Wallet Initialisers


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

# Overview

While investigating potential causes for slow shutdown of the node I noticed that we are writing checkpoints and doing archiving, but not actually closing the acid state db.

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [X] always close the acid state DB on shutdown
- [X] don't bother updating the archive on shutdown


# Comments

<!-- Additional comments or screenshots to attach if any -->

It's of no great benefit to do the archive stuff each time. The archive cleanup gets run by the worker periodicically.

We should also consider whether creating the checkpoint is also always needed on shutdown. If it's slow we might want to not bother, since we have to shutdown promptly or the process gets killed anyway. It's only for exchanges and ease of migration that we write the checkpoint and we can perhaps distinguish that use case. For example we could do a checkpoint on SIGUSR1 or SIGHUP.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
