### PR TITLE
[BIP44-239] Extend newTx to EO wallets

### DIFF
--- a/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/src/Cardano/Wallet/Kernel/BListener.hs
@@ -53,12 +53,12 @@ import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.Prefiltering (PrefilteredBlock)
 import qualified Cardano.Wallet.Kernel.Prefiltering as P
 import           Cardano.Wallet.Kernel.Read (foreignPendingByAccount,
-                     getEosPools, getFOWallets, getWalletSnapshot)
+                     getEosPools, getFOWallets, getWalletSnapshot,
+                     mkEosAddress)
 import           Cardano.Wallet.Kernel.Restore
 import qualified Cardano.Wallet.Kernel.Submission as Submission
 import           Cardano.Wallet.Kernel.Util.NonEmptyMap (NonEmptyMap)
 import qualified Cardano.Wallet.Kernel.Util.NonEmptyMap as NEM
-import           Cardano.Wallet.Kernel.Wallets (mkEosAddress)
 import           Cardano.Wallet.WalletLayer.Kernel.Wallets
                      (blundToResolvedBlock)
 

--- a/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -45,6 +45,8 @@ module Cardano.Wallet.Kernel.DB.AcidState (
     -- * Errors
   , NewPendingError(..)
   , NewForeignError(..)
+  , IsNewTxError
+  , newTxUnknownAccountErr
   , SwitchToForkInternalError(..)
   ) where
 
@@ -125,6 +127,9 @@ defDB = DB initHdWallets noUpdates
   Custom errors
 -------------------------------------------------------------------------------}
 
+class IsNewTxError a where
+    newTxUnknownAccountErr :: UnknownHdAccount -> a
+
 -- | Errors thrown by 'newPending'
 data NewPendingError =
     -- | Unknown account
@@ -133,6 +138,9 @@ data NewPendingError =
     -- | Some inputs are not in the wallet utxo
   | NewPendingFailed Spec.NewPendingFailed
 
+instance IsNewTxError NewPendingError where
+    newTxUnknownAccountErr = NewPendingUnknown
+
 -- | Errors thrown by 'newForeign'
 data NewForeignError =
     -- | Unknown account
@@ -140,6 +148,9 @@ data NewForeignError =
 
     -- | Some inputs are not in the wallet utxo
   | NewForeignFailed Spec.NewForeignFailed
+
+instance IsNewTxError NewForeignError where
+    newTxUnknownAccountErr = NewForeignUnknown
 
 -- | Errors thrown by 'SwitchToFork'
 data SwitchToForkInternalError =

--- a/src/Cardano/Wallet/Kernel/Read.hs
+++ b/src/Cardano/Wallet/Kernel/Read.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.Kernel.Read (
     -- ** Eos Helper
   , getEosPools
   , addressPoolGapByRootId
+  , mkEosAddress
     -- Errors
   , GetAddressPoolGapError (..)
     -- ** The only effectful getter you will ever need
@@ -26,7 +27,7 @@ import           Formatting (bprint, build, sformat, (%))
 import qualified Formatting.Buildable
 import           Serokell.Util (listJson)
 
-import           Pos.Core (Address)
+import           Pos.Core (Address, makePubKeyAddressBoot)
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, PublicKey)
 import           Pos.Util.Wlog (Severity (..))
@@ -194,6 +195,13 @@ addressPoolGapByRootId rootId db
         Nothing -> -- not an EO wallet
             Left $ GetEosWalletErrorWrongAccounts (sformat build rootId)
         Just res -> snd <$> res
+
+mkEosAddress
+    :: ProtocolMagic
+    -> PublicKey
+    -> Address
+mkEosAddress pm
+    = makePubKeyAddressBoot (makeNetworkMagic pm)
 
 data GetAddressPoolGapError =
       GetEosWalletErrorNoAccounts Text

--- a/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -1,7 +1,6 @@
 module Cardano.Wallet.Kernel.Wallets (
       createHdWallet
     , createEosHdWallet
-    , mkEosAddress
     , updateHdWallet
     , updatePassword
     , deleteHdWallet
@@ -29,11 +28,11 @@ import qualified Formatting.Buildable
 import           Data.Acid.Advanced (update')
 
 import           Pos.Chain.Txp (Utxo)
-import           Pos.Core (Address, Timestamp, makePubKeyAddressBoot)
+import           Pos.Core (Address, Timestamp)
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
-import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ProtocolMagic,
-                     PublicKey, changeEncPassphrase, checkPassMatches,
-                     emptyPassphrase, firstHardened, safeDeterministicKeyGen)
+import           Pos.Crypto (EncryptedSecretKey, PassPhrase, PublicKey,
+                     changeEncPassphrase, checkPassMatches, emptyPassphrase,
+                     firstHardened, safeDeterministicKeyGen)
 
 import           Cardano.Mnemonic (Mnemonic)
 import qualified Cardano.Mnemonic as Mnemonic
@@ -273,13 +272,6 @@ createEosHdWallet pw accounts gap assuranceLevel walletName = do
             mkBase (pk, ix) = HdAccountBaseEO (accId ix) pk gap
         in
             flip Map.singleton (mempty, mempty) . mkBase
-
-mkEosAddress
-    :: ProtocolMagic
-    -> PublicKey
-    -> Address
-mkEosAddress pm
-    = makePubKeyAddressBoot (makeNetworkMagic pm)
 
 -- | Creates an HD wallet where new accounts and addresses are generated
 -- via random index derivation.


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

https://github.com/input-output-hk/cardano-wallet/issues/239

<p align="right">#</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have extended NewTx (used in NewPending/NewForeign) to apply EO prefiltering when adding a transaction to an EO Account

# Comments

<!-- Additional comments or screenshots to attach if any -->

These changes add a new capability (new Tx for EO wallets) and does not test it yet. 
Existing tests for "newTx for HdRnd wallets" are still satisfied so we can be sure that this does not break any existing functionality.

Since both @piotr-iohk and I want to test this new functionality next  (on API and Kernel level respectively) I suggest we review/merge this without tests to allow concurrent work between us. 

NOTE: Adding tests for this on kernel level requires generalising the NewPayment Tests to EO wallets. These tests are also used by Tx and TxMeta tests, which also need to be generalised to EO wallets.




<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->