### PR TITLE
Revert recent NodeStateAdaptor changes (#87)

### DIFF
--- a/src/Cardano/Wallet/Action.hs
+++ b/src/Cardano/Wallet/Action.hs
@@ -28,7 +28,6 @@ import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import           Cardano.Wallet.Kernel.Migration (migrateLegacyDataLayer)
 import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 import           Cardano.Wallet.Kernel.NodeStateAdaptor (newNodeStateAdaptor)
-import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as NodeStateAdaptor
 import           Cardano.Wallet.Server.CLI (WalletBackendParams (..),
                      walletDbPath, walletNodeAddress, walletRebuildDb)
 import           Cardano.Wallet.Server.Middlewares
@@ -67,8 +66,6 @@ actionWithWallet
             genesisConfig
             nodeRes
             ntpStatus
-            NodeStateAdaptor.toMonadIO
-            nodeClient
 
     liftIO $ Keystore.bracketLegacyKeystore userSecret $ \keystore -> do
         let dbPath = walletDbPath walletDbOptions


### PR DESCRIPTION
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

<p align="right">#</p>

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] ~Reverted~Reset [`NodeStateAdaptor.hs`](https://github.com/input-output-hk/cardano-wallet/commits/develop/src/Cardano/Wallet/Kernel/NodeStateAdaptor.hs) to 1da9ca509d571fd18ef6e103795e7161dd697f26
- [x] Fixed errors (where we create it) until it compiled
- [x] Re-Added `retrying` for node api connection check

# Comments
This is not a complete revert of #87. There were several good things in there, like CLI changes, actually starting the node server, and cleanup.

- [ ] I should write a ticket if we're doing this
<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->